### PR TITLE
Bugfix missing and exists filters

### DIFF
--- a/src/filters/exists-filter.js
+++ b/src/filters/exists-filter.js
@@ -1,14 +1,13 @@
 /**
  * Construct an Exists filter.
  *
- * @param  {String} field Field name to query over.
- * @param  {String} term  Query value.
+ * @param  {String} field Field name to check existence.
  * @return {Object}       Exists filter.
  */
-export default function existsFilter(field, term) {
+export default function existsFilter(field) {
   return {
     exists: {
-      [field]: term
+      field
     }
   }
 }

--- a/src/filters/missing-filter.js
+++ b/src/filters/missing-filter.js
@@ -1,14 +1,13 @@
 /**
  * Construct a Missing filter.
  *
- * @param  {String} field Field name to query over.
- * @param  {String} term  Query value.
+ * @param  {String} field Field name to check if missing.
  * @return {Object}       Missing filter.
  */
-export default function missingFilter(field, term) {
+export default function missingFilter(field) {
   return {
     missing: {
-      [field]: term
+      field
     }
   }
 }

--- a/test/aggregations/missing-aggregation.js
+++ b/test/aggregations/missing-aggregation.js
@@ -3,7 +3,7 @@ import {expect} from 'chai'
 
 describe('missingAggregation', () => {
 
-  it('should create a min aggregation', () => {
+  it('should create a missing aggregation', () => {
     let result = missingAggregation('user', 'agg_name')
     expect(result).to.eql({
       agg_name: {

--- a/test/filters/exists-filter.js
+++ b/test/filters/exists-filter.js
@@ -4,10 +4,10 @@ import {expect} from 'chai'
 describe('existsFilter', () => {
 
   it('should create a simple exists filter', () => {
-    let result = existsFilter('user', 'kimchy')
+    let result = existsFilter('user')
     expect(result).to.eql({
       exists: {
-        user: 'kimchy'
+        field: 'user'
       }
     })
   })

--- a/test/filters/missing-filter.js
+++ b/test/filters/missing-filter.js
@@ -4,10 +4,10 @@ import {expect} from 'chai'
 describe('missingFilter', () => {
 
   it('should create a simple missing filter', () => {
-    let result = missingFilter('user', 'kimchy')
+    let result = missingFilter('user')
     expect(result).to.eql({
       missing: {
-        user: 'kimchy'
+        field: 'user'
       }
     })
   })


### PR DESCRIPTION
## What changed
- Fixes definitions for `missing` and `exists` filters.
- Fixes typo in test description.

## Notes

Previously these filters would come out as
```
missing: {
  user: 'kimchy'
}
```

when they should be
```
missing: {
  field: 'user'
}
```

Note to self: copy-paste is a dangerous convenience.