### PR TITLE
Add options argument to all aggregations that take additional options

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,10 @@ this pattern:
 * `fieldToAggregate` - The name of the field in your index to aggregate over.
 * `aggregationName` - (optional) A custom name for the aggregation. Defaults to
 `agg_<aggregationType>_<fieldToAggregate>`.
-* `nestingFunction` - (optional) A function used to define aggregations as children of the one being created. This _must_ be the last parameter set.
+* `aggregationOptions` - (optional) Additional key-value pairs to include in the
+aggregation object.
+* `nestingFunction` - (optional) A function used to define aggregations as
+children of the one being created. This _must_ be the last parameter set.
 
 ```js
 var body = new BodyBuilder().aggregation('terms', 'user').build()

--- a/src/aggregations/avg-aggregation.js
+++ b/src/aggregations/avg-aggregation.js
@@ -1,17 +1,25 @@
+import _ from 'lodash'
+
 /**
  * Construct a Avg aggregation.
  *
- * @param  {String} field Field name to aggregate over.
- * @param  {String} name  Aggregation name. Defaults to agg_avg_<field>.
- * @return {Object}       Avg Aggregation.
+ * @param  {String} field  Field name to aggregate over.
+ * @param  {String} [name] Aggregation name. Defaults to agg_avg_<field>.
+ * @param  {Object} opts   Additional options to include in the aggregation.
+ * @return {Object}        Avg Aggregation.
  */
-export default function avgAggregation(field, name) {
+export default function avgAggregation(field, name, opts) {
+  if (_.isObject(name)) {
+    let tmp = opts
+    opts = name
+    name = tmp
+  }
+
   name = name || `agg_avg_${field}`
+
   return {
     [name]: {
-      avg: {
-        field: field
-      }
+      avg: (() => _.merge({field}, opts))()
     }
   }
 }

--- a/src/aggregations/cardinality-aggregation.js
+++ b/src/aggregations/cardinality-aggregation.js
@@ -3,14 +3,20 @@ import _ from 'lodash'
 /**
  * Construct a Cardinality aggregation
  *
- * @param  {String} field Field name to aggregate over.
- * @param  {String} opts  Additional options to include in the aggregation.
- * @param  {String} name  Aggregation name. Defaults to agg_cardinality_<field>.
- * @return {Object}       Cardinality Aggregation.
+ * @param  {String} field  Field name to aggregate over.
+ * @param  {String} [name] Aggregation name. Defaults to agg_cardinality_<field>.
+ * @param  {Object} opts   Additional options to include in the aggregation.
+ * @return {Object}        Cardinality Aggregation.
  */
+export default function cardinalityAggregation(field, name, opts) {
+  if (_.isObject(name)) {
+    let tmp = opts
+    opts = name
+    name = tmp
+  }
 
-export default function cardinalityAggregation(field, opts, name) {
   name = name || `agg_cardinality_${field}`
+
   return {
     [name]: {
       cardinality: (() => _.merge({field}, opts))()

--- a/src/aggregations/date-histogram-aggregation.js
+++ b/src/aggregations/date-histogram-aggregation.js
@@ -3,13 +3,20 @@ import _ from 'lodash'
 /**
  * Construct a Date Histogram aggregation.
  *
- * @param  {String} field Field name to aggregate over.
- * @param  {String} opts  Additional options to include in the aggregation.
- * @param  {String} name  Aggregation name. Defaults to agg_date_histogram_<field>.
- * @return {Object}       Date Histogram Aggregation.
+ * @param  {String} field  Field name to aggregate over.
+ * @param  {String} [name] Aggregation name. Defaults to agg_date_histogram_<field>.
+ * @param  {Object} opts   Additional options to include in the aggregation.
+ * @return {Object}        Date Histogram Aggregation.
  */
-export default function dateHistogramAggregation(field, opts, name) {
+export default function dateHistogramAggregation(field, name, opts) {
+  if (_.isObject(name)) {
+    let tmp = opts
+    opts = name
+    name = tmp
+  }
+
   name = name || `agg_date_histogram_${field}`
+
   return {
     [name]: {
       date_histogram: (() => _.merge({field}, opts))()

--- a/src/aggregations/extended-stats-aggregation.js
+++ b/src/aggregations/extended-stats-aggregation.js
@@ -1,17 +1,25 @@
+import _ from 'lodash'
+
 /**
  * Construct a Extended Stats aggregation.
  *
- * @param  {String} field Field name to aggregate over.
- * @param  {String} name  Aggregation name. Defaults to agg_extended_stats_<field>.
- * @return {Object}       Extended Stats Aggregation.
+ * @param  {String} field  Field name to aggregate over.
+ * @param  {String} [name] Aggregation name. Defaults to agg_extended_stats_<field>.
+ * @param  {Object} opts   Additional options to include in the aggregation.
+ * @return {Object}        Extended Stats Aggregation.
  */
-export default function extendedStatsAggregation(field, name) {
+export default function extendedStatsAggregation(field, name, opts) {
+  if (_.isObject(name)) {
+    let tmp = opts
+    opts = name
+    name = tmp
+  }
+
   name = name || `agg_extended_stats_${field}`
+
   return {
     [name]: {
-      extended_stats: {
-        field: field
-      }
+      extended_stats: (() => _.merge({field}, opts))()
     }
   }
 }

--- a/src/aggregations/geohash-aggregation.js
+++ b/src/aggregations/geohash-aggregation.js
@@ -3,13 +3,20 @@ import _ from 'lodash'
 /**
  * Construct a Geohash grid aggregation.
  *
- * @param  {String} field Field name to aggregate over.
- * @param  {String} opts  Additional options to include in the aggregation.
- * @param  {String} name  Aggregation name. Defaults to agg_histogram_<field>.
- * @return {Object}       Histogram Aggregation.
+ * @param  {String} field  Field name to aggregate over.
+ * @param  {String} [name] Aggregation name. Defaults to agg_histogram_<field>.
+ * @param  {Object} opts   Additional options to include in the aggregation.
+ * @return {Object}        Histogram Aggregation.
  */
-export default function geohashAggregation(field, opts, name) {
+export default function geohashAggregation(field, name, opts) {
+  if (_.isObject(name)) {
+    let tmp = opts
+    opts = name
+    name = tmp
+  }
+
   name = name || `agg_geohash_grid_${field}`
+
   return {
     [name]: {
       geohash_grid: (() => _.merge({field}, opts))()

--- a/src/aggregations/histogram-aggregation.js
+++ b/src/aggregations/histogram-aggregation.js
@@ -3,13 +3,20 @@ import _ from 'lodash'
 /**
  * Construct a Histogram aggregation.
  *
- * @param  {String} field Field name to aggregate over.
- * @param  {String} opts  Additional options to include in the aggregation.
- * @param  {String} name  Aggregation name. Defaults to agg_histogram_<field>.
- * @return {Object}       Histogram Aggregation.
+ * @param  {String} field  Field name to aggregate over.
+ * @param  {String} [name] Aggregation name. Defaults to agg_histogram_<field>.
+ * @param  {Object} opts   Additional options to include in the aggregation.
+ * @return {Object}        Histogram Aggregation.
  */
-export default function histogramAggregation(field, opts, name) {
+export default function histogramAggregation(field, name, opts) {
+  if (_.isObject(name)) {
+    let tmp = opts
+    opts = name
+    name = tmp
+  }
+
   name = name || `agg_histogram_${field}`
+
   return {
     [name]: {
       histogram: (() => _.merge({field}, opts))()

--- a/src/aggregations/max-aggregation.js
+++ b/src/aggregations/max-aggregation.js
@@ -1,17 +1,25 @@
+import _ from 'lodash'
+
 /**
  * Construct a Max aggregation.
  *
- * @param  {String} field Field name to aggregate over.
- * @param  {String} name  Aggregation name. Defaults to agg_max_<field>.
- * @return {Object}       Max aggregation.
+ * @param  {String} field  Field name to aggregate over.
+ * @param  {String} [name] Aggregation name. Defaults to agg_max_<field>.
+ * @param  {Object} opts   Additional options to include in the aggregation.
+ * @return {Object}        Max aggregation.
  */
-export default function maxAggregation(field, name) {
+export default function maxAggregation(field, name, opts) {
+  if (_.isObject(name)) {
+    let tmp = opts
+    opts = name
+    name = tmp
+  }
+
   name = name || `agg_max_${field}`
+
   return {
     [name]: {
-      max: {
-        field: field
-      }
+      max: (() => _.merge({field}, opts))()
     }
   }
 }

--- a/src/aggregations/min-aggregation.js
+++ b/src/aggregations/min-aggregation.js
@@ -1,17 +1,25 @@
+import _ from 'lodash'
+
 /**
  * Construct a Min aggregation.
  *
- * @param  {String} field Field name to aggregate over.
- * @param  {String} name  Aggregation name. Defaults to agg_min_<field>.
- * @return {Object}       Min aggregation.
+ * @param  {String} field  Field name to aggregate over.
+ * @param  {String} [name] Aggregation name. Defaults to agg_min_<field>.
+ * @param  {Object} opts   Additional options to include in the aggregation.
+ * @return {Object}        Min aggregation.
  */
-export default function minAggregation(field, name) {
+export default function minAggregation(field, name, opts) {
+  if (_.isObject(name)) {
+    let tmp = opts
+    opts = name
+    name = tmp
+  }
+
   name = name || `agg_min_${field}`
+
   return {
     [name]: {
-      min: {
-        field: field
-      }
+      min: (() => _.merge({field}, opts))()
     }
   }
 }

--- a/src/aggregations/percentiles-aggregation.js
+++ b/src/aggregations/percentiles-aggregation.js
@@ -3,13 +3,20 @@ import _ from 'lodash'
 /**
  * Construct a Percentiles aggregation.
  *
- * @param  {String} field Field name to aggregate over.
- * @param  {String} opts  Additional options to include in the aggregation.
- * @param  {String} name  Aggregation name. Defaults to agg_percentiles_<field>.
- * @return {Object}       Percentiles Aggregation.
+ * @param  {String} field  Field name to aggregate over.
+ * @param  {String} [name] Aggregation name. Defaults to agg_percentiles_<field>.
+ * @param  {Object} opts   Additional options to include in the aggregation.
+ * @return {Object}        Percentiles Aggregation.
  */
-export default function percentilesAggregation(field, opts, name) {
+export default function percentilesAggregation(field, name, opts) {
+  if (_.isObject(name)) {
+    let tmp = opts
+    opts = name
+    name = tmp
+  }
+
   name = name || `agg_percentiles_${field}`
+
   return {
     [name]: {
       percentiles: (() => _.merge({field}, opts))()

--- a/src/aggregations/range-aggregation.js
+++ b/src/aggregations/range-aggregation.js
@@ -3,13 +3,20 @@ import _ from 'lodash'
 /**
  * Construct a Range aggregation.
  *
- * @param  {String} field Field name to aggregate over.
- * @param  {String} name  Aggregation name. Defaults to agg_terms_<field>.
- * @param  {Object} opts  Additional options to include in the aggregation.
- * @return {Object}       Range aggregation.
+ * @param  {String} field  Field name to aggregate over.
+ * @param  {String} [name] Aggregation name. Defaults to agg_terms_<field>.
+ * @param  {Object} opts   Additional options to include in the aggregation.
+ * @return {Object}        Range aggregation.
  */
 export default function rangeAggregation(field, name, opts) {
+  if (_.isObject(name)) {
+    let tmp = opts
+    opts = name
+    name = tmp
+  }
+
   name = name || `agg_range_${field}`
+
   return {
     [name]: {
       range: (() => _.assign({field}, opts))()

--- a/src/aggregations/significant-terms-aggregation.js
+++ b/src/aggregations/significant-terms-aggregation.js
@@ -1,17 +1,25 @@
+import _ from 'lodash'
+
 /**
  * Construct a Significant Terms aggregation.
  *
- * @param  {String} field Field name to aggregate over.
- * @param  {String} name  Aggregation name. Defaults to agg_significant_terms_<field>.
- * @return {Object}       Significant Terms aggregation.
+ * @param  {String} field  Field name to aggregate over.
+ * @param  {String} [name] Aggregation name. Defaults to agg_significant_terms_<field>.
+ * @param  {Object} opts   Additional options to include in the aggregation.
+ * @return {Object}        Significant Terms aggregation.
  */
-export default function significantTermsAggregation(field, name) {
+export default function significantTermsAggregation(field, name, opts) {
+  if (_.isObject(name)) {
+    let tmp = opts
+    opts = name
+    name = tmp
+  }
+
   name = name || `agg_significant_terms_${field}`
+
   return {
     [name]: {
-      significant_terms: {
-        field: field
-      }
+      significant_terms: (() => _.merge({field}, opts))()
     }
   }
 }

--- a/src/aggregations/stats-aggregation.js
+++ b/src/aggregations/stats-aggregation.js
@@ -1,17 +1,25 @@
+import _ from 'lodash'
+
 /**
  * Construct a Stats aggregation.
  *
- * @param  {String} field Field name to aggregate over.
- * @param  {String} name  Aggregation name. Defaults to agg_stats_<field>.
- * @return {Object}       Stats Aggregation.
+ * @param  {String} field  Field name to aggregate over.
+ * @param  {String} [name] Aggregation name. Defaults to agg_stats_<field>.
+ * @param  {Object} opts   Additional options to include in the aggregation.
+ * @return {Object}        Stats Aggregation.
  */
-export default function statsAggregation(field, name) {
+export default function statsAggregation(field, name, opts) {
+  if (_.isObject(name)) {
+    let tmp = opts
+    opts = name
+    name = tmp
+  }
+
   name = name || `agg_stats_${field}`
+
   return {
     [name]: {
-      stats: {
-        field: field
-      }
+      stats: (() => _.merge({field}, opts))()
     }
   }
 }

--- a/src/aggregations/sum-aggregation.js
+++ b/src/aggregations/sum-aggregation.js
@@ -1,17 +1,25 @@
+import _ from 'lodash'
+
 /**
  * Construct a Sum aggregation.
  *
- * @param  {String} field Field name to aggregate over.
- * @param  {String} name  Aggregation name. Defaults to agg_sum_<field>.
- * @return {Object}       Sum Aggregation.
+ * @param  {String} field  Field name to aggregate over.
+ * @param  {String} [name] Aggregation name. Defaults to agg_sum_<field>.
+ * @param  {Object} opts   Additional options to include in the aggregation.
+ * @return {Object}        Sum Aggregation.
  */
-export default function sumAggregation(field, name) {
+export default function sumAggregation(field, name, opts) {
+  if (_.isObject(name)) {
+    let tmp = opts
+    opts = name
+    name = tmp
+  }
+
   name = name || `agg_sum_${field}`
+
   return {
     [name]: {
-      sum: {
-        field: field
-      }
+      sum: (() => _.assign({field}, opts))()
     }
   }
 }

--- a/src/aggregations/terms-aggregation.js
+++ b/src/aggregations/terms-aggregation.js
@@ -3,13 +3,20 @@ import _ from 'lodash'
 /**
  * Construct a Terms aggregation.
  *
- * @param  {String} field Field name to aggregate over.
- * @param  {String} name  Aggregation name. Defaults to agg_terms_<field>.
- * @param  {Object} opts  Additional options to include in the aggregation.
- * @return {Object}       Terms aggregation.
+ * @param  {String} field  Field name to aggregate over.
+ * @param  {String} [name] Aggregation name. Defaults to agg_terms_<field>.
+ * @param  {Object} opts   Additional options to include in the aggregation.
+ * @return {Object}        Terms aggregation.
  */
 export default function termsAggregation(field, name, opts) {
+  if (_.isObject(name)) {
+    let tmp = opts
+    opts = name
+    name = tmp
+  }
+
   name = name || `agg_terms_${field}`
+
   return {
     [name]: {
       terms: (() => _.assign({field}, opts))()

--- a/src/aggregations/top-hits-aggregation.js
+++ b/src/aggregations/top-hits-aggregation.js
@@ -1,21 +1,30 @@
+import _ from 'lodash'
+
 /**
  * Internal counter for added top hits aggregations.
  * @type {Number}
  */
-let count = 0;
+let count = 0
 
 /**
  * Construct a Top hits aggregation.
  *
- * @param  {Object} opts  Options to include in the aggregation. Defaults to {}.
- * @param  {String} name  Aggregation name. Defaults to 'agg_top_hits_{count}'.
- * @return {Object}       Top hits Aggregation.
+ * @param  {String} [name] Aggregation name. Defaults to 'agg_top_hits_{count}'.
+ * @param  {Object} opts   Options to include in the aggregation.
+ * @return {Object}        Top hits Aggregation.
  */
-export default function topHitsAggregation(opts = {}, name) {
+export default function topHitsAggregation(name, opts) {
+  if (_.isObject(name)) {
+    let tmp = opts
+    opts = name
+    name = tmp
+  }
+
   name = name || `agg_top_hits_${count++}`
+
   return {
     [name]: {
-      top_hits: opts
+      top_hits: (() => _.assign({}, opts))()
     }
   }
 }

--- a/src/aggregations/value-count-aggregation.js
+++ b/src/aggregations/value-count-aggregation.js
@@ -1,17 +1,25 @@
+import _ from 'lodash'
+
 /**
  * Construct a Value Count aggregation.
  *
- * @param  {String} field Field name to aggregate over.
- * @param  {String} name  Aggregation name. Defaults to agg_value_count_<field>.
- * @return {Object}       Value Count Aggregation.
+ * @param  {String} field  Field name to aggregate over.
+ * @param  {String} [name] Aggregation name. Defaults to agg_value_count_<field>.
+ * @param  {Object} opts   Additional options to include in the aggregation.
+ * @return {Object}        Value Count Aggregation.
  */
-export default function valueCountAggregation(field, name) {
+export default function valueCountAggregation(field, name, opts) {
+  if (_.isObject(name)) {
+    let tmp = opts
+    opts = name
+    name = tmp
+  }
+
   name = name || `agg_value_count_${field}`
+
   return {
     [name]: {
-      value_count: {
-        field: field
-      }
+      value_count: (() => _.assign({field}, opts))()
     }
   }
 }

--- a/test/aggregations/avg-aggregation.js
+++ b/test/aggregations/avg-aggregation.js
@@ -14,4 +14,18 @@ describe('avgAggregation', () => {
     })
   })
 
+  it('should include additional options', () => {
+    let result = avgAggregation('grade', {
+      missing: 10
+    })
+    expect(result).to.eql({
+      agg_avg_grade: {
+        avg: {
+          field: 'grade',
+          missing: 10
+        }
+      }
+    })
+  })
+
 })

--- a/test/aggregations/extended-stats-aggregation.js
+++ b/test/aggregations/extended-stats-aggregation.js
@@ -14,4 +14,18 @@ describe('extendedStatsAggregation', () => {
     })
   })
 
+  it('should include custom options', () => {
+    let result = extendedStatsAggregation('grade', {
+      size: 10
+    })
+    expect(result).to.eql({
+      agg_extended_stats_grade: {
+        extended_stats: {
+          field: 'grade',
+          size: 10
+        }
+      }
+    })
+  })
+
 })

--- a/test/aggregations/max-aggregation.js
+++ b/test/aggregations/max-aggregation.js
@@ -14,4 +14,18 @@ describe('maxAggregation', () => {
     })
   })
 
+  it('should include additional options', () => {
+    let result = maxAggregation('grade', {
+      missing: 10
+    })
+    expect(result).to.eql({
+      agg_max_grade: {
+        max: {
+          field: 'grade',
+          missing: 10
+        }
+      }
+    })
+  })
+
 })

--- a/test/aggregations/min-aggregation.js
+++ b/test/aggregations/min-aggregation.js
@@ -14,4 +14,18 @@ describe('minAggregation', () => {
     })
   })
 
+  it('should include additional options', () => {
+    let result = minAggregation('grade', {
+      missing: 10
+    })
+    expect(result).to.eql({
+      agg_min_grade: {
+        min: {
+          field: 'grade',
+          missing: 10
+        }
+      }
+    })
+  })
+
 })

--- a/test/aggregations/significant-terms-aggregation.js
+++ b/test/aggregations/significant-terms-aggregation.js
@@ -14,4 +14,18 @@ describe('significantTermsAggregation', () => {
     })
   })
 
+  it('should include additional options', () => {
+    let result = significantTermsAggregation('user', {
+      size: 10
+    })
+    expect(result).to.eql({
+      agg_significant_terms_user: {
+        significant_terms: {
+          field: 'user',
+          size: 10
+        }
+      }
+    })
+  })
+
 })

--- a/test/aggregations/stats-aggregation.js
+++ b/test/aggregations/stats-aggregation.js
@@ -14,4 +14,28 @@ describe('statsAggregation', () => {
     })
   })
 
+  it('should include additional options', () => {
+    let result = statsAggregation('grade', {
+      script: {
+        inline: '_value * correction',
+        params: {
+          correction: 1.2
+        }
+      }
+    })
+    expect(result).to.eql({
+      agg_stats_grade: {
+        stats: {
+          field: 'grade',
+          script: {
+            inline: '_value * correction',
+            params: {
+              correction: 1.2
+            }
+          }
+        }
+      }
+    })
+  })
+
 })

--- a/test/aggregations/sum-aggregation.js
+++ b/test/aggregations/sum-aggregation.js
@@ -14,4 +14,20 @@ describe('sumAggregation', () => {
     })
   })
 
+  it('should allow a script property', () => {
+    let result = sumAggregation('funds', 'Balance', {
+      script: "doc['DEBIT_DC'].value + doc['CREDIT_DC'].value",
+      lang: "expression"
+    })
+    expect(result).to.eql({
+      Balance: {
+        sum: {
+          field: 'funds',
+          script: "doc['DEBIT_DC'].value + doc['CREDIT_DC'].value",
+          lang: "expression"
+        }
+      }
+    })
+  })
+
 })

--- a/test/aggregations/terms-aggregation.js
+++ b/test/aggregations/terms-aggregation.js
@@ -34,4 +34,24 @@ describe('termsAggregation', () => {
     })
   })
 
+  it('should allow name argument to be optional', () => {
+    let result = termsAggregation('user', {
+      order: {
+        timestamp: 'asc'
+      },
+      size: 0
+    })
+    expect(result).to.eql({
+      agg_terms_user: {
+        terms: {
+          field: 'user',
+          order: {
+            timestamp: 'asc'
+          },
+          size: 0
+        }
+      }
+    })
+  })
+
 })

--- a/test/aggregations/top-hits-aggregation.js
+++ b/test/aggregations/top-hits-aggregation.js
@@ -13,7 +13,7 @@ describe('topHitsAggregation', () => {
   })
 
   it('should create a top_hits aggregation with custom name', () => {
-    let result = topHitsAggregation(undefined, 'agg_name')
+    let result = topHitsAggregation('agg_name')
     expect(result).to.eql({
       agg_name: {
         top_hits: {}
@@ -38,6 +38,19 @@ describe('topHitsAggregation', () => {
               'title'
             ]
           },
+          size: 10
+        }
+      }
+    })
+  })
+
+  it('should create a top_hits aggregation with custom options and name', () => {
+    let result = topHitsAggregation('agg_name', {
+      size: 10
+    })
+    expect(result).to.eql({
+      agg_name: {
+        top_hits: {
           size: 10
         }
       }

--- a/test/aggregations/value-count-aggregation.js
+++ b/test/aggregations/value-count-aggregation.js
@@ -14,4 +14,28 @@ describe('valueCountAggregation', () => {
     })
   })
 
+  it('should include additional options', () => {
+    let result = valueCountAggregation('grade', {
+      script: {
+        file: 'my_script',
+        params: {
+          field: 'grade'
+        }
+      }
+    })
+    expect(result).to.eql({
+      agg_value_count_grade: {
+        value_count: {
+          field: 'grade',
+          script: {
+            file: 'my_script',
+            params: {
+              field: 'grade'
+            }
+          }
+        }
+      }
+    })
+  })
+
 })


### PR DESCRIPTION
Normalizes the function signature for aggregations across the codebase. 

Now can include an optional `opts` object as the third argument, containing any arbitrary parameters to be merged into the aggregation clause. This was previously available in some aggregations like `terms` but not in others, so this is mainly an effort to keep consistency across all of the aggregations.

Example: 
```js
new Bodybuilder().aggregation('max', 'grade', {missing: 10}).build()
// {
//   aggregations: {
//     agg_max_grade: {
//       max: {
//         field: 'grade',
//         missing: 10
//       }
//     }
//   }
// }
// 
```