### PR TITLE
Whitelist files for npm publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "browser/",
     "lib/",
     "src/",
-    "repl.js",
+    "repl.js"
   ],
   "scripts": {
     "build:babel": "babel src --out-dir lib",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,12 @@
   "version": "1.15.1",
   "description": "An elasticsearch query body builder.",
   "main": "lib/index.js",
+  "files": [
+    "browser/",
+    "lib/",
+    "src/",
+    "repl.js",
+  ],
   "scripts": {
     "build:babel": "babel src --out-dir lib",
     "build:umd": "webpack lib browser/bodybuilder.min.js",


### PR DESCRIPTION
Should help to reduce the bloat in `npm install bodybuilder`.