### PR TITLE
Add filter aggregations

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,15 +179,22 @@ To add a filter aggregation, the second argument expects a callback. You will be
 ```js
 var body = new BodyBuilder()
   .aggregation('filter', filterBuilder => {
-    return filterBuilder.filter('term', 'user', 'kimchy')
-  }, 'kimchy_filter', nestedAggregationCallback)
+    return filterBuilder.filter('term', 'color', 'red')
+  }, 'red_products', agg => agg.aggregation('avg', 'price', 'avg_price'))
   .build()
 // body == {
-//   aggregations: {
-//     kimchy_filter: {
-//       filter: {
-//         term: {
-//           user: "kimchy"
+//   "aggregations": {
+//     "red_products": {
+//       "filter": {
+//         "term": {
+//           "color": "red"
+//         }
+//       },
+//       "aggs": {
+//         "avg_price": {
+//           "avg": {
+//             "field": "price"
+//           }
 //         }
 //       }
 //     }

--- a/README.md
+++ b/README.md
@@ -173,6 +173,28 @@ var body = new BodyBuilder().aggregation('terms', 'code', null, {
 //}
 ```
 
+#### Filter Aggregations
+To add a filter aggregation, the second argument expects a callback. You will be passed a filter-builder with which you can build filters just like you normally do with BodyBuilder. The last argument here is also the callback for nested aggregations.
+
+```js
+var body = new BodyBuilder()
+  .aggregation('filter', filterBuilder => {
+    return filterBuilder.filter('term', 'user', 'kimchy')
+  }, 'kimchy_filter', nestedAggregationCallback)
+  .build()
+// body == {
+//   aggregations: {
+//     kimchy_filter: {
+//       filter: {
+//         term: {
+//           user: "kimchy"
+//         }
+//       }
+//     }
+//   }
+// }
+```
+
 ### Combining queries, filters, and aggregations
 
 Multiple queries and filters are merged using the boolean query or filter (see

--- a/src/aggregations/filter-aggregation.js
+++ b/src/aggregations/filter-aggregation.js
@@ -1,0 +1,33 @@
+import _ from 'lodash'
+import FilterBuilder from '../filters/filter-builder'
+
+/**
+ * Construct a Filter aggregation.
+ *
+ * @memberof Aggregations
+ *
+ * @param  {String} filterCb Callback function that will be passed the
+ *                           FilterBuilder
+ * @param  {String} name     Aggregation name. Defaults to agg_filter.
+ * @param  {Object} opts     Additional options to include in the aggregation.
+ * @return {Object}          Filter Aggregation.
+ */
+export default function filterAggregation(filterCb, name, opts) {
+  if (_.isObject(name)) {
+    const tmp = opts
+    opts = name
+    name = tmp
+  }
+
+  name = name || `agg_filter`
+
+  const filterBuilder = new FilterBuilder()
+
+  filterCb(filterBuilder)
+
+  return {
+    [name]: {
+      filter: filterBuilder.filters
+    }
+  }
+}

--- a/src/aggregations/index.js
+++ b/src/aggregations/index.js
@@ -2,6 +2,7 @@ import avgAggregation from './avg-aggregation'
 import cardinalityAggregation from './cardinality-aggregation'
 import dateHistogramAggregation from './date-histogram-aggregation'
 import extendedStatsAggregation from './extended-stats-aggregation'
+import filterAggregation from './filter-aggregation'
 import histogramAggregation from './histogram-aggregation'
 import maxAggregation from './max-aggregation'
 import minAggregation from './min-aggregation'
@@ -39,6 +40,7 @@ export default {
   extended_stats: extendedStatsAggregation,
   'extended-stats': extendedStatsAggregation,
   extendedStats: extendedStatsAggregation,
+  filter: filterAggregation,
   histogram: histogramAggregation,
   max: maxAggregation,
   min: minAggregation,

--- a/src/filters/filter-builder.js
+++ b/src/filters/filter-builder.js
@@ -1,0 +1,60 @@
+import { cloneDeep } from 'lodash'
+import filters from './index'
+import { boolMerge } from '../utils'
+
+export default class FilterBuilder {
+  constructor () {
+    this._filters = {}
+  }
+  /**
+   * Apply a filter of a given type providing all the necessary arguments,
+   * passing these arguments directly to the specified filter builder. Merges
+   * existing filter(s) with the new filter.
+   *
+   * @param  {String}  type Name of the filter type.
+   * @param  {...args} args Arguments passed to filter builder.
+   * @returns {FilterBuilder} Builder class.
+   */
+  filter(type, ...args) {
+    this._filter('and', type, ...args)
+    return this
+  }
+
+  _filter(boolType, filterType, ...args) {
+    let klass = filters[filterType]
+    let newFilter
+
+    if (!klass) {
+      throw new TypeError(`Filter type ${filterType} not found.`)
+    }
+
+    newFilter = klass(...args)
+    this._filters = boolMerge(newFilter, this._filters, boolType)
+    return this
+  }
+
+  /**
+   * Alias to FilterBuilder#filter.
+   *
+   * @private
+   *
+   * @returns {FilterBuilder} Builder class.
+   */
+  andFilter(...args) {
+    return this._filter('and', ...args)
+  }
+
+  orFilter(type, ...args) {
+    this._filter('or', type, ...args)
+    return this
+  }
+
+  notFilter(type, ...args) {
+    this._filter('not', type, ...args)
+    return this
+  }
+
+  get filters () {
+    return cloneDeep(this._filters)
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 import _ from 'lodash'
-import filters from './filters'
+import FilterBuilder from './filters/filter-builder'
 import queries from './queries'
 import AggregationBuilder from './aggregations/aggregation-builder'
 import { boolMerge, sortMerge } from './utils'
@@ -16,7 +16,7 @@ class Bodybuilder {
 
   constructor() {
     this._body = {}
-    this._filters = {}
+    this._filterBuilder = new FilterBuilder()
     this._queries = {}
     this._aggBuilder = Object.create(AggregationBuilder)
   }
@@ -33,7 +33,7 @@ class Bodybuilder {
 
   _buildV1() {
     let body = _.clone(this._body)
-    const filters = this._filters
+    const filters = this._filterBuilder.filters
     const queries = this._queries
     const aggregations = this._aggBuilder.aggregations
 
@@ -57,7 +57,7 @@ class Bodybuilder {
 
   _buildV2() {
     let body = _.clone(this._body)
-    const filters = this._filters
+    const filters = this._filterBuilder.filters
     const queries = this._queries
     const aggregations = this._aggBuilder.aggregations
 
@@ -156,42 +156,23 @@ class Bodybuilder {
    * @param  {...args} args Arguments passed to filter builder.
    * @returns {Bodybuilder} Builder class.
    */
-  filter(type, ...args) {
-    this._filter('and', type, ...args)
+  filter(...args) {
+    this._filterBuilder.filter(...args)
     return this
   }
 
-  _filter(boolType, filterType, ...args) {
-    let klass = filters[filterType]
-    let newFilter
-
-    if (!klass) {
-      throw new TypeError(`Filter type ${filterType} not found.`)
-    }
-
-    newFilter = klass(...args)
-    this._filters = boolMerge(newFilter, this._filters, boolType)
-    return this
-  }
-
-  /**
-   * Alias to Bodybuilder#filter.
-   *
-   * @private
-   *
-   * @returns {Bodybuilder} Builder class.
-   */
   andFilter(...args) {
-    return this._filter(...args)
-  }
-
-  orFilter(type, ...args) {
-    this._filter('or', type, ...args)
+    this._filterBuilder.andFilter(...args)
     return this
   }
 
-  notFilter(type, ...args) {
-    this._filter('not', type, ...args)
+  orFilter(...args) {
+    this._filterBuilder.orFilter(...args)
+    return this
+  }
+
+  notFilter(...args) {
+    this._filterBuilder.notFilter(...args)
     return this
   }
 

--- a/test/aggregations/filter-aggregation.js
+++ b/test/aggregations/filter-aggregation.js
@@ -1,0 +1,27 @@
+import filterAggregation from '../../src/aggregations/filter-aggregation'
+import FilterBuilder from '../../src/filters/filter-builder'
+import {expect} from 'chai'
+
+describe('filterAggregation', () => {
+  it('should call the cb with a FilterBuilder', function () {
+    let callCount = 0
+    filterAggregation(filters => {
+      callCount++
+      expect(filters).to.be.an.instanceOf(FilterBuilder)
+    })
+
+    expect(callCount).to.eq(1)
+  })
+
+  it('should create a filter aggregation', () => {
+    const result = filterAggregation(filters => {
+      filters.filter('term', 'user', 'John')
+    }, 'agg_name')
+    expect(result).to.eql({
+      agg_name: {
+        filter: { term: { user: 'John' } }
+      }
+    })
+  })
+
+})

--- a/test/index.js
+++ b/test/index.js
@@ -262,6 +262,34 @@ describe('BodyBuilder', () => {
     })
   })
 
+  it('should support nesting aggregations in filter aggregations', () => {
+    let result = new BodyBuilder()
+      .aggregation(
+        'filter',
+        filterBuilder => filterBuilder.filter('term', 'user', 'kimchy'),
+        agg => agg.aggregation('avg', 'value')
+      )
+      .build()
+    expect(result).to.eql({
+      aggregations: {
+        agg_filter: {
+          filter: {
+            term: {
+              user: 'kimchy'
+            }
+          },
+          aggs: {
+            agg_avg_value: {
+              avg: {
+                field: 'value'
+              }
+            }
+          }
+        }
+      }
+    })
+  })
+
   it('should add an aggregation and a filter', () => {
     let result = new BodyBuilder().filter('term', 'user', 'kimchy')
                                   .agg('terms', 'user')


### PR DESCRIPTION
I also had the need for a filter aggregation, but chose a more generic approach than https://github.com/danpaz/bodybuilder/pull/42.

I'm not sure if it's valid to choose any filter that bodybuilder (or in particular the new FilterBuilder) generates, but in particular the terms filter works quite well like this.

A signature like `function filterAggregation(filterType, filterField, filterValue, aggregationName)` seemed to simple, since it would essentially reduce the API to one particular filter.

Let me know what you think about this approach!