### PR TITLE
Adds support for the geo_shape filter.

### DIFF
--- a/src/filters/geo-shape-filter.js
+++ b/src/filters/geo-shape-filter.js
@@ -1,0 +1,19 @@
+
+/**
+ * Construct a geo shape filter.
+ *
+ * @memberof Filters
+ *
+ * @param  {String} field    Field name to query over.
+ * @param  {Object} shape    GeoJSON for intersection.
+ * @return {Object}          Geo shape filter.
+ */
+export default function geoShapeFilter(field, shape) {
+  return {
+    geo_shape: {
+      [field]: {
+        shape: shape
+      }
+    }
+  }
+}

--- a/src/filters/index.js
+++ b/src/filters/index.js
@@ -3,6 +3,7 @@ import existsFilter from './exists-filter'
 import fuzzyFilter from './fuzzy-filter'
 import geoBoundingBoxFilter from './geo-bounding-box-filter'
 import geoDistanceFilter from './geo-distance-filter'
+import geoShapeFilter from './geo-shape-filter'
 import idsFilter from './ids-filter'
 import matchAllFilter from './match-all-filter'
 import missingFilter from './missing-filter'
@@ -39,6 +40,10 @@ export default {
   geodistance: geoDistanceFilter,
   geoDistance: geoDistanceFilter,
   'geo-distance': geoDistanceFilter,
+  geo_shape: geoShapeFilter,
+  geoshape: geoShapeFilter,
+  geoShape: geoShapeFilter,
+  'geo-shape': geoShapeFilter,
   ids: idsFilter,
   matchAll: matchAllFilter,
   matchall: matchAllFilter,

--- a/test/filters/geo-shape-filter.js
+++ b/test/filters/geo-shape-filter.js
@@ -1,0 +1,35 @@
+
+import geoShapeFilter from '../../src/filters/geo-shape-filter'
+import {expect} from 'chai'
+
+describe('geoShapeFilter', () => {
+
+  it('should create a geo shape filter', () => {
+    let geoJSON = {
+      "type":"Feature",
+      "geometry":{
+        "type":"Polygon",
+        "coordinates":[
+          [
+            [28.7457275390625,41.04621681452063],
+            [29.042358398437496,41.11557271185201],
+            [29.27032470703125,41.001666266518185],
+            [29.097290039062496,40.88444793903562],
+            [28.78555297851562,40.94671366508002],
+            [28.7457275390625,41.04621681452063]
+          ]
+        ]
+      }
+    }
+    let result = geoShapeFilter('fieldName', geoJSON)
+
+    expect(result).to.eql({
+      geo_shape: {
+        fieldName: {
+          shape: geoJSON
+        }
+      }
+    })
+  })
+
+})


### PR DESCRIPTION
This PR adds support for the `geo_shape` elasticsearch filter.

See documentation at https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-geo-shape-query.html