### PR TITLE
split into individual builders

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "lint": "eslint src test",
     "style": "npm run lint",
     "test": "mocha --require babel-core/register --recursive test",
+    "test-bb": "babel-tape-runner test/body-builder.js | tap-spec",
     "watch:test": "mocha --watch --require babel-core/register --recursive test",
     "check": "npm run lint && npm test",
     "preversion": "npm run check && npm run build"

--- a/src/body-builder.js
+++ b/src/body-builder.js
@@ -44,10 +44,10 @@ function queryBuilder () {
       const nestedResult = nestedCallback(
         Object.assign(queryBuilder(), filterBuilder())
       )
-      if (_.size(nestedResult.getQuery())) {
+      if (nestedResult.hasQuery()) {
         nested.query = nestedResult.getQuery()
       }
-      if (_.size(nestedResult.getFilter())) {
+      if (nestedResult.hasFilter()) {
         nested.filter = nestedResult.getFilter()
       }
     }
@@ -80,6 +80,9 @@ function queryBuilder () {
     },
     getQuery () {
       return query
+    },
+    hasQuery () {
+      return !!_.size(query)
     }
   }
 }
@@ -94,13 +97,13 @@ function filterBuilder () {
       const nestedResult = nestedCallback(
         Object.assign(queryBuilder(), filterBuilder(), aggregationBuilder())
       )
-      if (_.size(nestedResult.getQuery())) {
+      if (nestedResult.hasQuery()) {
         nested.query = nestedResult.getQuery()
       }
-      if (_.size(nestedResult.getFilter())) {
+      if (nestedResult.hasFilter()) {
         nested.filter = nestedResult.getFilter()
       }
-      if (_.size(nestedResult.getAggregations())) {
+      if (nestedResult.hasAggregations()) {
         nested.aggs = nestedResult.getAggregations()
       }
     }
@@ -133,6 +136,9 @@ function filterBuilder () {
     },
     getFilter () {
       return filter
+    },
+    hasFilter () {
+      return !!_.size(filter)
     }
   }
 }
@@ -158,10 +164,10 @@ function aggregationBuilder () {
         aggregationBuilder(),
         filterBuilder()
       ))
-      if (_.size(nestedResult.getFilter())) {
+      if (nestedResult.hasFilter()) {
         nestedClause.filter = nestedResult.getFilter()
       }
-      if (_.size(nestedResult.getAggregations())) {
+      if (nestedResult.hasAggregations()) {
         nestedClause.aggs = nestedResult.getAggregations()
       }
     }
@@ -185,6 +191,9 @@ function aggregationBuilder () {
     },
     getAggregations () {
       return aggregations
+    },
+    hasAggregations () {
+      return !!_.size(aggregations)
     }
   }
 }

--- a/src/body-builder.js
+++ b/src/body-builder.js
@@ -1,0 +1,201 @@
+import _ from 'lodash'
+import {boolMerge} from './utils'
+
+const filterBuilderId = Symbol('filterBuilder')
+const queryBuilderId = Symbol('queryBuilder')
+const aggregationBuilderId = Symbol('aggregationBuilder')
+
+function bodyBuilder () {
+  return Object.assign(
+    { /* sort, from, build, etc. go here */ },
+    queryBuilder(),
+    filterBuilder(),
+    aggregationBuilder()
+  )
+}
+
+/**
+ * Generic builder for filter and query clauses
+ *
+ * @private
+ *
+ * @param  {string} field
+ * @param  {any}    value
+ * @param  {Object} opts
+ * @return {Object}       query clause component
+ */
+function buildClause(field, value, opts) {
+  const clause = {}
+
+  if (field && value && opts) {
+    Object.assign(clause, opts, {[field]: value})
+  } else if (field && value) {
+    clause[field] = value
+  } else if (field) {
+    clause.field = field
+  }
+
+  return clause
+}
+
+function queryBuilder () {
+  let query = {}
+
+  function makeQuery (boolType, queryType, ...args) {
+    const nested = {}
+    if (_.isFunction(_.last(args))) {
+      const nestedCallback = args.pop()
+      const nestedResult = nestedCallback(
+        Object.assign(queryBuilder(), filterBuilder())
+      )
+      if (_.size(nestedResult.getQuery())) {
+        nested.query = nestedResult.getQuery()
+      }
+      if (_.size(nestedResult.getFilter())) {
+        nested.filter = nestedResult.getFilter()
+      }
+    }
+
+    query = boolMerge(
+      {[queryType]: Object.assign(buildClause(...args), nested)},
+      query,
+      boolType
+    )
+  }
+
+  return {
+    query(...args) {
+      makeQuery('and', ...args)
+      return this
+    },
+    andQuery(...args) {
+      return this.query(...args)
+    },
+    addQuery(...args) {
+      return this.query(...args)
+    },
+    orQuery(...args) {
+      makeQuery('or', ...args)
+      return this
+    },
+    notQuery(...args) {
+      makeQuery('not', ...args)
+      return this
+    },
+    getQuery() {
+      return query
+    }
+  }
+}
+
+function filterBuilder() {
+  let filter = {}
+
+  function makeFilter(boolType, filterType, ...args) {
+    const nested = {}
+    if (_.isFunction(_.last(args))) {
+      const nestedCallback = args.pop()
+      const nestedResult = nestedCallback(
+        Object.assign(queryBuilder(), filterBuilder(), aggregationBuilder())
+      )
+      if (_.size(nestedResult.getQuery())) {
+        nested.query = nestedResult.getQuery()
+      }
+      if (_.size(nestedResult.getFilter())) {
+        nested.filter = nestedResult.getFilter()
+      }
+      if (_.size(nestedResult.getAggregations())) {
+        nested.aggs = nestedResult.getAggregations()
+      }
+    }
+
+    filter = boolMerge(
+      {[filterType]: Object.assign(buildClause(...args), nested)},
+      filter,
+      boolType
+    )
+  }
+
+  return {
+    filter(...args) {
+      makeFilter('and', ...args)
+      return this
+    },
+    andFilter(...args) {
+      return this.filter(...args)
+    },
+    addFilter(...args) {
+      return this.filter(...args)
+    },
+    orFilter(...args) {
+      makeFilter('or', ...args)
+      return this
+    },
+    notFilter(...args) {
+      makeFilter('not', ...args)
+      return this
+    },
+    getFilter() {
+      return filter
+    }
+  }
+}
+
+function buildAggregation (type, field, opts) {
+  return {
+    [type]: Object.assign({field}, opts)
+  }
+}
+
+function aggregationBuilder () {
+  const aggregations = {}
+
+  function makeAggregation (type, field, ...args) {
+    const aggName = _.find(args, _.isString) || `agg_${type}_${field}`
+    const opts = _.find(args, _.isPlainObject) || {}
+    const nested = _.find(args, _.isFunction)
+    const nestedClause = {}
+
+    if (_.isFunction(nested)) {
+      const recursiveResult = nested(Object.assign(
+        {},
+        aggregationBuilder(),
+        filterBuilder()
+      ))
+      if (_.size(nestedResult.getFilter())) {
+        nestedClause.filter = nestedResult.getFilter()
+      }
+      if (_.size(nestedResult.getAggregations())) {
+        nestedClause.aggs = nestedResult.getAggregations()
+      }
+    }
+
+    Object.assign(
+      aggregations,
+      {[aggName]: Object.assign(
+        buildAggregation(type, field, opts),
+        nestedClause
+      )}
+    )
+  }
+
+  return {
+    aggregation (...args) {
+      makeAggregation(...args)
+      return this
+    },
+    agg(...args) {
+      return this.aggregation(...args)
+    },
+    getAggregations () {
+      return aggregations
+    }
+  }
+}
+
+export {
+  queryBuilder,
+  bodyBuilder,
+  filterBuilder,
+  aggregationBuilder
+}

--- a/src/body-builder.js
+++ b/src/body-builder.js
@@ -1,10 +1,6 @@
 import _ from 'lodash'
 import {boolMerge} from './utils'
 
-const filterBuilderId = Symbol('filterBuilder')
-const queryBuilderId = Symbol('queryBuilder')
-const aggregationBuilderId = Symbol('aggregationBuilder')
-
 function bodyBuilder () {
   return Object.assign(
     { /* sort, from, build, etc. go here */ },
@@ -24,7 +20,7 @@ function bodyBuilder () {
  * @param  {Object} opts
  * @return {Object}       query clause component
  */
-function buildClause(field, value, opts) {
+function buildClause (field, value, opts) {
   const clause = {}
 
   if (field && value && opts) {
@@ -64,34 +60,34 @@ function queryBuilder () {
   }
 
   return {
-    query(...args) {
+    query (...args) {
       makeQuery('and', ...args)
       return this
     },
-    andQuery(...args) {
+    andQuery (...args) {
       return this.query(...args)
     },
-    addQuery(...args) {
+    addQuery (...args) {
       return this.query(...args)
     },
-    orQuery(...args) {
+    orQuery (...args) {
       makeQuery('or', ...args)
       return this
     },
-    notQuery(...args) {
+    notQuery (...args) {
       makeQuery('not', ...args)
       return this
     },
-    getQuery() {
+    getQuery () {
       return query
     }
   }
 }
 
-function filterBuilder() {
+function filterBuilder () {
   let filter = {}
 
-  function makeFilter(boolType, filterType, ...args) {
+  function makeFilter (boolType, filterType, ...args) {
     const nested = {}
     if (_.isFunction(_.last(args))) {
       const nestedCallback = args.pop()
@@ -117,25 +113,25 @@ function filterBuilder() {
   }
 
   return {
-    filter(...args) {
+    filter (...args) {
       makeFilter('and', ...args)
       return this
     },
-    andFilter(...args) {
+    andFilter (...args) {
       return this.filter(...args)
     },
-    addFilter(...args) {
+    addFilter (...args) {
       return this.filter(...args)
     },
-    orFilter(...args) {
+    orFilter (...args) {
       makeFilter('or', ...args)
       return this
     },
-    notFilter(...args) {
+    notFilter (...args) {
       makeFilter('not', ...args)
       return this
     },
-    getFilter() {
+    getFilter () {
       return filter
     }
   }
@@ -157,7 +153,7 @@ function aggregationBuilder () {
     const nestedClause = {}
 
     if (_.isFunction(nested)) {
-      const recursiveResult = nested(Object.assign(
+      const nestedResult = nested(Object.assign(
         {},
         aggregationBuilder(),
         filterBuilder()
@@ -184,7 +180,7 @@ function aggregationBuilder () {
       makeAggregation(...args)
       return this
     },
-    agg(...args) {
+    agg (...args) {
       return this.aggregation(...args)
     },
     getAggregations () {

--- a/src/utils.js
+++ b/src/utils.js
@@ -10,10 +10,8 @@ import queries from './queries'
  * @param {Object} target Target.
  * @returns {Object} Merged object.
  */
-export function mergeConcat(target) {
-  let args = Array.prototype.slice.call(arguments, 1)
-
-  args.unshift(target)
+export function mergeConcat() {
+  let args = Array.prototype.slice.call(arguments, 0)
   args.push(function customizer(a, b) {
     if (_.isPlainObject(a)) {
       return _.assignWith(a, b, customizer)


### PR DESCRIPTION
Quite a few things I'd change about the approach:

## Using plain old objects instead of `class` from ES6+
Thanks to the discussion https://github.com/danpaz/bodybuilder/pull/16#r60402704 I started looking into the reasoning behind it. Sure `class` looks slick, but this is a great use case for merging multiple `builders` together with no clear hierarchy... Thanks a lot to @nfantone for pointing this out!

This will change the API of bodybuilder, so that `new` is no longer required.

## Splitting up the bodybuilder into `queryBuilder`, `filterBuilder` and `aggregationBuilder`
This allows new elegance in the building of nested queries and aggregations. Imagine something like

```js
import {bodyBuilder, filterBuilder} from 'bodybuilder'

const kimchiFilter = filterBuilder().filter('term', 'user', 'kimchi')

const body = bodybuilder()
  .query('constant_score', () => kimchiFilter)
  .agg('filter', 'kimchi_agg', () => kimchiFilter)
  .build()
```

## Real hiding of private variables
`this._queries` etc. are not accessible anymore and truly private. This way private variables don't end up floating around for users to access. All methods the user can access are intended for them to use.

I'm really looking forward to your feedback @nfantone & @danpaz 