### PR TITLE
Added a filters aggregation

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,37 @@ var body = new BodyBuilder()
 // }
 ```
 
+##### Filters Aggregations
+A filters aggregation differs slightly from the filter aggregation in that you can provide multiple filters on which to aggregate. 
+
+```js
+var body = new BodyBuilder()
+  .aggregation('filters', filtersBuilder => {
+    return filtersBuilder.filter('colors','term', 'color', 'red')
+                         .filter('statuses', 'term', 'status', 'success')
+  }, 'products', agg => agg.aggregation('avg', 'price', 'avg_price'))
+  .build()
+// body == {
+//   "aggregations": {
+//     "products": {
+//       "filters": {
+//         "filters": {
+//           "colors": { "term": { "color": "red" } },
+//           "statuses": { "term": { "status": "success" } }
+//         }
+//       },
+//       "aggs": {
+//         "avg_price": {
+//           "avg": {
+//             "field": "price"
+//           }
+//         }
+//       }
+//     }
+//   }
+// }
+```
+
 ### Combining queries, filters, and aggregations
 
 Multiple queries and filters are merged using the boolean query or filter (see

--- a/src/aggregations/filters-aggregation.js
+++ b/src/aggregations/filters-aggregation.js
@@ -1,0 +1,35 @@
+import _ from 'lodash'
+import FiltersBuilder from '../filters/filters-builder'
+
+/**
+ * Construct a Filters aggregation.
+ *
+ * @memberof Aggregations
+ *
+ * @param  {String} filterCb Callback function that will be passed the
+ *                           FiltersBuilder
+ * @param  {String} name     Aggregation name. Defaults to agg_filter.
+ * @param  {Object} opts     Additional options to include in the aggregation.
+ * @return {Object}          Filter Aggregation.
+ */
+export default function filtersAggregation(filterCb, name, opts) {
+  if (_.isObject(name)) {
+    const tmp = opts
+    opts = name
+    name = tmp
+  }
+
+  name = name || `agg_filters`
+
+  const filtersBuilder = new FiltersBuilder()
+
+  filterCb(filtersBuilder)
+
+  return {
+    [name]: {
+      filters: {
+        filters: filtersBuilder.filters
+      }
+    }
+  }
+}

--- a/src/aggregations/index.js
+++ b/src/aggregations/index.js
@@ -4,6 +4,7 @@ import childrenAggregation from './children-aggregation'
 import dateHistogramAggregation from './date-histogram-aggregation'
 import extendedStatsAggregation from './extended-stats-aggregation'
 import filterAggregation from './filter-aggregation'
+import filtersAggregation from './filter-aggregation'
 import geohashAggregation from './geohash-aggregation'
 import globalAggregation from './global-aggregation'
 import histogramAggregation from './histogram-aggregation'
@@ -45,6 +46,7 @@ export default {
   'extended-stats': extendedStatsAggregation,
   extendedStats: extendedStatsAggregation,
   filter: filterAggregation,
+  filters: filtersAggregation,
   geohash: geohashAggregation,
   global: globalAggregation,
   histogram: histogramAggregation,

--- a/src/filters/filters-builder.js
+++ b/src/filters/filters-builder.js
@@ -1,0 +1,39 @@
+import { cloneDeep } from 'lodash'
+import filters from './index'
+import { mergeConcat } from '../utils'
+
+export default class FiltersBuilder {
+  constructor () {
+    this._filters = {}
+  }
+  /**
+   * Apply a filter of a given type providing all the necessary arguments,
+   * passing these arguments directly to the specified filter builder. Merges
+   * existing filter(s) with the new filter.
+   *
+   * @private
+   *
+   * @param  {String}  name Name of the filter.
+   * @param  {String}  type Name of the filter type.
+   * @param  {...args} args Arguments passed to filter builder.
+   * @returns {FilterBuilder} Builder class.
+   */
+  filter(name, type, ...args) {
+    let klass = filters[type]
+    let newFilter
+
+    if (!klass) {
+      throw new TypeError(`Filter type ${type} not found.`)
+    }
+
+    newFilter = {}
+    newFilter[name] = klass(...args)
+
+    this._filters = mergeConcat({}, newFilter, this._filters)
+    return this
+  }
+
+  get filters () {
+    return cloneDeep(this._filters)
+  }
+}

--- a/test/aggregations/filters-aggregation.js
+++ b/test/aggregations/filters-aggregation.js
@@ -1,0 +1,33 @@
+import filtersAggregation from '../../src/aggregations/filters-aggregation'
+import FiltersBuilder from '../../src/filters/filters-builder'
+import {expect} from 'chai'
+
+describe('filtersAggregation', () => {
+  it('should call the cb with a FiltersBuilder', function () {
+    let callCount = 0
+    filtersAggregation(filters => {
+      callCount++
+      expect(filters).to.be.an.instanceOf(FiltersBuilder)
+    })
+
+    expect(callCount).to.eq(1)
+  })
+
+  it('should create a filter aggregation', () => {
+    const result = filtersAggregation(filters => {
+      filters.filter('users', 'term', 'user', 'John')
+      filters.filter('errors', 'term', 'status', 'failure')
+    }, 'agg_name')
+    expect(result).to.eql({
+      agg_name: {
+        filters: {
+          filters: {
+            users: { term: { user: 'John' } },
+            errors: { term: { status: 'failure' } }
+          }
+        }
+      }
+    })
+  })
+
+})


### PR DESCRIPTION
I have intentioanlly left the filters class out of the filters index since it should only used by the filters-aggregation.
This should allow bodybuilder to follow the [filters aggregation](https://www.elastic.co/guide/en/elasticsearch/reference/2.4/search-aggregations-bucket-filters-aggregation.html) pattern.