### PR TITLE
Adds support for scripted metric aggregation

### DIFF
--- a/src/aggregations/index.js
+++ b/src/aggregations/index.js
@@ -14,6 +14,7 @@ import nestedAggregation from './nested-aggregation'
 import percentilesAggregation from './percentiles-aggregation'
 import rangeAggregation from './range-aggregation'
 import reverseNestedAggregation from './reverse-nested-aggregation'
+import scriptedMetricAggregation from './scripted-metric-aggregation'
 import significantTermsAggregation from './significant-terms-aggregation'
 import statsAggregation from './stats-aggregation'
 import sumAggregation from './sum-aggregation'
@@ -58,6 +59,10 @@ export default {
   reverse_nested: reverseNestedAggregation,
   'reverse-nested': reverseNestedAggregation,
   reverseNested: reverseNestedAggregation,
+  scriptedmetric: scriptedMetricAggregation,
+  scripted_metric: scriptedMetricAggregation,
+  'scripted-metric': scriptedMetricAggregation,
+  scriptedMetric: scriptedMetricAggregation,
   significantterms: significantTermsAggregation,
   significant_terms: significantTermsAggregation,
   'significant-terms': significantTermsAggregation,

--- a/src/aggregations/scripted-metric-aggregation.js
+++ b/src/aggregations/scripted-metric-aggregation.js
@@ -1,0 +1,27 @@
+import _ from 'lodash'
+
+/**
+ * Construct a Scripted Metric aggregation.
+ *
+ * @memberof Aggregations
+ *
+ * @param  {String} map_script The script as a string associated to the map_script step.
+ * @param  {String} [name] Aggregation name. Defaults to agg_scripted_metric.
+ * @param  {Object} opts   Additional options to include in the aggregation.
+ * @return {Object}        Scripted Metric aggregation.
+ */
+export default function scriptedMetricAggregation(map_script, name, opts) {
+  if (_.isObject(name)) {
+    let tmp = opts
+    opts = name
+    name = tmp
+  }
+
+  name = name || `agg_scripted_metric`
+
+  return {
+    [name]: {
+      scripted_metric: (() => _.merge({map_script}, opts))()
+    }
+  }
+}

--- a/test/aggregations/scripted-metric-aggregation.js
+++ b/test/aggregations/scripted-metric-aggregation.js
@@ -1,0 +1,34 @@
+import scriptedMetricAggregation from '../../src/aggregations/scripted-metric-aggregation'
+import {expect} from 'chai'
+
+let map_script = {"file": "file_name"}
+let init_script = "_agg.transactions = []"
+
+describe('scriptedMetricAggregation', () => {
+
+  it('should create a scripted metric aggregation', () => {
+    let result = scriptedMetricAggregation(map_script, 'profit')
+    expect(result).to.eql({
+      profit: {
+        scripted_metric: {
+          map_script: map_script
+        }
+      }
+    })
+  })
+
+  it('should include additional options', () => {
+    let result = scriptedMetricAggregation(map_script, 'profit', {
+      init_script: init_script,
+    })
+    expect(result).to.eql({
+      profit: {
+        scripted_metric: {
+          map_script: map_script,
+          init_script: init_script
+        }
+      }
+    })
+  })
+
+})

--- a/test/aggregations/scripted-metric-aggregation.js
+++ b/test/aggregations/scripted-metric-aggregation.js
@@ -19,7 +19,7 @@ describe('scriptedMetricAggregation', () => {
 
   it('should include additional options', () => {
     let result = scriptedMetricAggregation(map_script, 'profit', {
-      init_script: init_script,
+      init_script: init_script
     })
     expect(result).to.eql({
       profit: {


### PR DESCRIPTION
Addresses #95

Following the ES docs, the script_metric aggregation is pretty
straightforward to create. Unit tests assert map_script as an object
argument but can also be passed in as a string.