### PR TITLE
Make elasticsearch 2.x query dsl the default output for filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ elasticsearch with a simple, predictable api.
 
 ## Compatibility
 
-Currently aims to support the full elasticsearch query DSL for versions 1.x.
-The elasticsearch 2.x query DSL is supported by providing a `v2` arguments
-when calling `build` function.
+Currently aims to support the full elasticsearch query DSL for versions 1.x,
+2.x, and 5.x.
 
-Contributions are welcome!
+The elasticsearch 1.x query DSL is supported by providing a `v1` argument
+when calling the `build` function.
 
 ## Install
 
@@ -26,8 +26,8 @@ Contributions are welcome!
 var Bodybuilder = require('bodybuilder')
 var body = new Bodybuilder() // A builder instance.
 body.query('match', 'message', 'this is a test')
-body.build() // Build 1.x DSL
-body.build('v2') // Build 2.x DSL
+body.build() // Build 2.x DSL
+body.build('v1') // Build 1.x DSL
 ```
 
 For each elasticsearch query body, create an instance of `Bodybuilder`, apply
@@ -95,7 +95,7 @@ pattern:
 var body = new Bodybuilder().filter('term', 'message', 'test').build()
 // body == {
 //   query: {
-//     filtered: {
+//     bool: {
 //       filter: {
 //         term: {
 //           message: 'test'
@@ -292,7 +292,7 @@ var body  = new BodyBuilder().filter('term', 'message', 'test')
 //     }
 //   ],
 //   query: {
-//     filtered: {
+//     bool: {
 //       filter: {
 //         term: {
 //           message: 'test'
@@ -317,7 +317,7 @@ var body = new Bodybuilder().filter('term', 'message', 'test')
 //   size: 5,
 //   from: 10,
 //   query: {
-//     filtered: {
+//     bool: {
 //       filter: {
 //         term: {
 //           message: 'test'
@@ -340,7 +340,7 @@ var body = new Bodybuilder().filter('term', 'message', 'test')
 // body == {
 //   _sourceExclude: 'verybigfield',
 //   query: {
-//     filtered: {
+//     bool: {
 //       filter: {
 //         term: {
 //           message: 'test'

--- a/src/index.js
+++ b/src/index.js
@@ -78,11 +78,11 @@ export default function bodybuilder () {
         const filters = this.getFilter()
         const aggregations = this.getAggregations()
 
-        if (version === 'v2') {
-          return _buildV2(body, queries, filters, aggregations)
+        if (version === 'v1') {
+          return _buildV1(body, queries, filters, aggregations)
         }
 
-        return _buildV1(body, queries, filters, aggregations)
+        return _build(body, queries, filters, aggregations)
       }
 
     },
@@ -112,7 +112,7 @@ function _buildV1(body, queries, filters, aggregations) {
   return clonedBody
 }
 
-function _buildV2(body, queries, filters, aggregations) {
+function _build(body, queries, filters, aggregations) {
   let clonedBody = _.cloneDeep(body)
 
   if (!_.isEmpty(filters)) {

--- a/test/index.js
+++ b/test/index.js
@@ -23,6 +23,46 @@ test('bodyBuilder should build query with field but no value', (t) => {
   })
 })
 
+test('bodyBuilder should build filter without query', (t) => {
+  t.plan(1)
+
+  const result = bodyBuilder()
+    .filter('term', 'user', 'kimchy')
+    .build()
+
+  t.deepEqual(result, {
+    query: {
+      bool: {
+        filter: {
+          term: {
+            user: 'kimchy'
+          }
+        }
+      }
+    }
+  })
+})
+
+test('bodyBuilder should build v1 filtered query', (t) => {
+  t.plan(1)
+
+  const result = bodyBuilder()
+    .filter('term', 'user', 'kimchy')
+    .build('v1')
+
+  t.deepEqual(result, {
+    query: {
+      filtered: {
+        filter: {
+          term: {
+            user: 'kimchy'
+          }
+        }
+      }
+    }
+  })
+})
+
 test('bodyBuilder should create query and filter', (t) => {
   t.plan(2)
 
@@ -42,13 +82,13 @@ test('bodyBuilder should create query and filter', (t) => {
   })
 })
 
-test('bodyBuilder should build a filtered query', (t) => {
+test('bodyBuilder should build a v1 filtered query', (t) => {
   t.plan(1)
 
   const result = bodyBuilder()
     .query('match', 'message', 'this is a test')
     .filter('term', 'user', 'kimchy')
-    .build()
+    .build('v1')
 
   t.deepEqual(result, {
     query: {
@@ -68,6 +108,31 @@ test('bodyBuilder should build a filtered query', (t) => {
   })
 })
 
+test('bodyBuilder should build a filtered query', (t) => {
+  t.plan(1)
+
+  const result = bodyBuilder()
+    .query('match', 'message', 'this is a test')
+    .filter('term', 'user', 'kimchy')
+    .build()
+
+  t.deepEqual(result, {
+    query: {
+      bool: {
+        must: {
+          match: {
+            message: 'this is a test'
+          }
+        },
+        filter: {
+          term: {
+            user: 'kimchy'
+          }
+        }
+      }
+    }
+  })
+})
 
 test('bodyBuilder should build a filtered query for version 2.x', (t) => {
   t.plan(1)
@@ -275,12 +340,12 @@ test('bodyBuilder should create this big-ass query', (t) => {
   const result = bodyBuilder().query('constant_score', (q) => {
     return q
       .orFilter('term', 'created_by.user_id', 'abc')
-      .orFilter('nested', 'path', 'doc_meta', {}, (q) => {
+      .orFilter('nested', 'path', 'doc_meta', (q) => {
         return q.query('constant_score', (q) => {
           return q.filter('term', 'doc_meta.user_id', 'abc')
         })
       })
-      .orFilter('nested', 'path', 'tests', {}, (q) => {
+      .orFilter('nested', 'path', 'tests', (q) => {
         return q.query('constant_score', (q) => {
           return q.filter('term', 'tests.created_by.user_id', 'abc')
         })


### PR DESCRIPTION
As discussed in #79, bodybuilder 2 will make the elasticsearch 2.x Query DSL the default. That means bodybuilder-built filters will live in the `query.bool.filter` context instead of in the _deprecated_ filtered query. The [elasticsearch docs](https://www.elastic.co/guide/en/elasticsearch/reference/5.1/query-filter-context.html) have more information. 

Practically, this means if you were doing `.build('v2')` in your bodybuilder queries you will no longer need to do so in bodybuilder 2 (when it's released). If you are using `build()` without the `'v2'` argument please be aware of this change, and if you want to preserve the old functionality pass the argument `'v1'` to `build('v1')`. 

