### PR TITLE
Add minimumShouldMatch for bool.should queries

### DIFF
--- a/src/filter-builder.js
+++ b/src/filter-builder.js
@@ -6,6 +6,13 @@ import aggregationBuilder from './aggregation-builder'
 export default function filterBuilder () {
   let filter = {}
 
+  function addMinimumShouldMatch(str) {
+    const shouldClause = _.get(filter, 'bool.should')
+    if (shouldClause && shouldClause.length > 1) {
+      filter.bool['minimum_should_match'] = str
+    }
+  }
+
   function makeFilter (boolType, filterType, ...args) {
     const nested = {}
     if (_.isFunction(_.last(args))) {
@@ -101,6 +108,19 @@ export default function filterBuilder () {
      */
     notFilter (...args) {
       makeFilter('not', ...args)
+      return this
+    },
+
+    /**
+     * Set the `minimum_should_match` property on a bool filter with more than
+     * one `should` clause.
+     *
+     * @param  {any} param  minimum_should_match parameter. For possible values
+     *                      see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-minimum-should-match.html
+     * @return {bodybuilder} Builder.
+     */
+    filterMinimumShouldMatch (param) {
+      addMinimumShouldMatch(param)
       return this
     },
 

--- a/src/query-builder.js
+++ b/src/query-builder.js
@@ -125,8 +125,16 @@ export default function queryBuilder () {
       return this
     },
 
-    minimumShouldMatch (str) {
-      addMinimumShouldMatch(str)
+    /**
+     * Set the `minimum_should_match` property on a bool query with more than
+     * one `should` clause.
+     *
+     * @param  {any} param  minimum_should_match parameter. For possible values
+     *                      see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-minimum-should-match.html
+     * @return {bodybuilder} Builder.
+     */
+    queryMinimumShouldMatch (param) {
+      addMinimumShouldMatch(param)
       return this
     },
 

--- a/src/query-builder.js
+++ b/src/query-builder.js
@@ -5,6 +5,13 @@ import filterBuilder from './filter-builder'
 export default function queryBuilder () {
   let query = {}
 
+  function addMinimumShouldMatch(str) {
+    const shouldClause = _.get(query, 'bool.should')
+    if (shouldClause && shouldClause.length > 1) {
+      query.bool['minimum_should_match'] = str
+    }
+  }
+
   function makeQuery (boolType, queryType, ...args) {
     const nested = {}
     if (_.isFunction(_.last(args))) {
@@ -115,6 +122,11 @@ export default function queryBuilder () {
      */
     notQuery (...args) {
       makeQuery('not', ...args)
+      return this
+    },
+
+    minimumShouldMatch (str) {
+      addMinimumShouldMatch(str)
       return this
     },
 

--- a/test/index.js
+++ b/test/index.js
@@ -518,3 +518,88 @@ test('bodybuilder | or filter', (t) => {
     }
   })
 })
+
+test('bodybuilder | minimum_should_match filter', (t) => {
+  t.plan(1)
+
+  const result = bodyBuilder()
+    .orFilter('term', 'user', 'kimchy')
+    .orFilter('term', 'user', 'tony')
+    .filterMinimumShouldMatch(2)
+    .build()
+
+  t.deepEqual(result,
+  {
+    query: {
+      bool: {
+        filter: {
+          bool: {
+            should: [
+              {term: {user: 'kimchy'}},
+              {term: {user: 'tony'}}
+            ],
+            minimum_should_match: 2
+          }
+        }
+      }
+    }
+  })
+})
+
+test('bodybuilder | minimum_should_match query', (t) => {
+  t.plan(1)
+
+  const result = bodyBuilder()
+    .orQuery('term', 'user', 'kimchy')
+    .orQuery('term', 'user', 'tony')
+    .queryMinimumShouldMatch(2)
+    .build()
+
+  t.deepEqual(result,
+  {
+    query: {
+      bool: {
+        should: [
+          {term: {user: 'kimchy'}},
+          {term: {user: 'tony'}}
+        ],
+        minimum_should_match: 2
+      }
+    }
+  })
+})
+
+test('bodybuilder | minimum_should_match query and filter', (t) => {
+  t.plan(1)
+
+  const result = bodyBuilder()
+    .orQuery('term', 'user', 'kimchy')
+    .orQuery('term', 'user', 'tony')
+    .orFilter('term', 'user', 'kimchy')
+    .orFilter('term', 'user', 'tony')
+    .filterMinimumShouldMatch(1)
+    .queryMinimumShouldMatch(2)
+    .build()
+
+  t.deepEqual(result,
+  {
+    query: {
+      bool: {
+        should: [
+          {term: {user: 'kimchy'}},
+          {term: {user: 'tony'}}
+        ],
+        minimum_should_match: 2,
+        filter: {
+          bool: {
+            should: [
+              {term: {user: 'kimchy'}},
+              {term: {user: 'tony'}}
+            ],
+            minimum_should_match: 1
+          }
+        }
+      }
+    }
+  })
+})

--- a/test/query-builder.js
+++ b/test/query-builder.js
@@ -656,3 +656,46 @@ test('queryBuilder | or', (t) => {
     ]
   })
 })
+
+test('queryBuilder | minimum_should_match with one query ignores minimum', (t) => {
+  t.plan(1)
+
+  const result = queryBuilder()
+    .orQuery('term', 'status', 'alert')
+    .minimumShouldMatch(2)
+
+  t.deepEqual(result.getQuery(), {
+    bool: {
+      should: [{
+        term: {
+          status: 'alert'
+        }
+      }]
+    }
+  })
+})
+
+test('queryBuilder | minimum_should_match with multiple queries', (t) => {
+  t.plan(1)
+
+  const result = queryBuilder()
+    .orQuery('term', 'status', 'alert')
+    .orQuery('term', 'status', 'normal')
+    .minimumShouldMatch(2)
+
+  t.deepEqual(result.getQuery(), {
+    bool: {
+      should: [{
+        term: {
+          status: 'alert'
+        }
+      }, {
+        term: {
+          status: 'normal'
+        }
+      }],
+      minimum_should_match: 2
+    }
+  })
+
+})

--- a/test/query-builder.js
+++ b/test/query-builder.js
@@ -662,7 +662,7 @@ test('queryBuilder | minimum_should_match with one query ignores minimum', (t) =
 
   const result = queryBuilder()
     .orQuery('term', 'status', 'alert')
-    .minimumShouldMatch(2)
+    .queryMinimumShouldMatch(2)
 
   t.deepEqual(result.getQuery(), {
     bool: {
@@ -681,7 +681,7 @@ test('queryBuilder | minimum_should_match with multiple queries', (t) => {
   const result = queryBuilder()
     .orQuery('term', 'status', 'alert')
     .orQuery('term', 'status', 'normal')
-    .minimumShouldMatch(2)
+    .queryMinimumShouldMatch(2)
 
   t.deepEqual(result.getQuery(), {
     bool: {


### PR DESCRIPTION
Resolves #114. 

@mikeholmesuk @diegoprd can either or both of you pull this branch and give this a try? Any thoughts?

```js
bodybuilder()
  .orQuery('foo')
  .orQuery('bar')
  .minimumShouldMatch(2)
  .build()
```

TODO 
- [ ] jsdoc for this method