### PR TITLE
Update build to only use lodash set, as lodash merge has issues prope…

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,21 +31,21 @@
   ],
   "license": "MIT",
   "devDependencies": {
-    "babel-cli": "6.5.1",
-    "babel-core": "6.5.1",
-    "babel-plugin-lodash": "2.0.1",
-    "babel-preset-es2015": "6.5.0",
-    "babel-register": "6.18.0",
+    "babel-cli": "6.24.0",
+    "babel-core": "6.24.0",
+    "babel-plugin-lodash": "3.2.11",
+    "babel-preset-es2015": "6.24.0",
+    "babel-register": "6.24.0",
     "babel-tape-runner": "2.0.1",
-    "documentation": "4.0.0-beta10",
+    "documentation": "4.0.0-beta.18",
     "eslint": "1.10.2",
     "tap-spec": "4.1.1",
-    "tape": "4.6.2",
-    "tape-watch": "2.2.4",
-    "webpack": "1.12.13"
+    "tape": "4.6.3",
+    "tape-watch": "2.3.0",
+    "webpack": "2.2.1"
   },
   "dependencies": {
-    "lodash": "4.9.0"
+    "lodash": "4.17.4"
   },
   "repository": {
     "type": "git",

--- a/src/index.js
+++ b/src/index.js
@@ -177,15 +177,12 @@ function _build(body, queries, filters, aggregations) {
   let clonedBody = _.cloneDeep(body)
 
   if (!_.isEmpty(filters)) {
-    let filterBody = {}
-    let queryBody = {}
-    _.set(filterBody, 'query.bool.filter', filters)
     if (!_.isEmpty(queries.bool)) {
-      _.set(queryBody, 'query.bool', queries.bool)
+      _.set(clonedBody, 'query.bool', queries.bool)
     } else if (!_.isEmpty(queries)) {
-      _.set(queryBody, 'query.bool.must', queries)
+      _.set(clonedBody, 'query.bool.must', queries)
     }
-    _.merge(clonedBody, filterBody, queryBody)
+    _.set(clonedBody, 'query.bool.filter', filters)
   } else if (!_.isEmpty(queries)) {
     _.set(clonedBody, 'query', queries)
   }


### PR DESCRIPTION
…rly setting orFilter should property

Related to https://github.com/danpaz/bodybuilder/issues/122 

Weird behaviour where I was unable to produce a test that failed before this change, but would work after. It always worked, even when using a copy of my use case that was failing locally before, but fixed after my change. Might be a babel transpilation issue that causes the merge to behave has expected in tests, but not when the library is required in and used.