### PR TITLE
Fix nested query issue

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ import _ from 'lodash'
 import queryBuilder from './query-builder'
 import filterBuilder from './filter-builder'
 import aggregationBuilder from './aggregation-builder'
-import { sortMerge } from './utils'
+import { sortMerge, build, buildV1 } from './utils'
 
 /**
  * **http://bodybuilder.js.org**
@@ -140,10 +140,10 @@ export default function bodybuilder () {
         const aggregations = this.getAggregations()
 
         if (version === 'v1') {
-          return _buildV1(body, queries, filters, aggregations)
+          return buildV1(body, queries, filters, aggregations)
         }
 
-        return _build(body, queries, filters, aggregations)
+        return build(body, queries, filters, aggregations)
       }
 
     },
@@ -151,50 +151,6 @@ export default function bodybuilder () {
     filterBuilder(),
     aggregationBuilder()
   )
-}
-
-function _buildV1(body, queries, filters, aggregations) {
-  let clonedBody = _.cloneDeep(body)
-
-  if (!_.isEmpty(filters)) {
-    _.set(clonedBody, 'query.filtered.filter', filters)
-
-    if (!_.isEmpty(queries)) {
-      _.set(clonedBody, 'query.filtered.query', queries)
-    }
-
-  } else if (!_.isEmpty(queries)) {
-    _.set(clonedBody, 'query', queries)
-  }
-
-  if (!_.isEmpty(aggregations)) {
-    _.set(clonedBody, 'aggregations', aggregations)
-  }
-  return clonedBody
-}
-
-function _build(body, queries, filters, aggregations) {
-  let clonedBody = _.cloneDeep(body)
-
-  if (!_.isEmpty(filters)) {
-    let filterBody = {}
-    let queryBody = {}
-    _.set(filterBody, 'query.bool.filter', filters)
-    if (!_.isEmpty(queries.bool)) {
-      _.set(queryBody, 'query.bool', queries.bool)
-    } else if (!_.isEmpty(queries)) {
-      _.set(queryBody, 'query.bool.must', queries)
-    }
-    _.merge(clonedBody, filterBody, queryBody)
-  } else if (!_.isEmpty(queries)) {
-    _.set(clonedBody, 'query', queries)
-  }
-
-  if (!_.isEmpty(aggregations)) {
-    _.set(clonedBody, 'aggs', aggregations)
-  }
-
-  return clonedBody
 }
 
 module.exports = bodybuilder


### PR DESCRIPTION
Fixes https://github.com/danpaz/bodybuilder/issues/142.

The added test case describes the scenario quite well: nesting with `query` added a `query` node to bool where it should have added a `must`. When I tried to fix it, it became clear that using `filter` in the context of `'nested'` or `'has_parent'` has only worked with elasticsearch version 1.x.

This MR represents a breaking change for people using elasticsearch v 1.x!

We could work around this by changing some of the inner workings of bodybuilder: We know the version of the query language once `build()` is executed, so if we defer the execution of all `makeFilter` and `makeQuery` calls to only be executed once `build` is called, we can pass along the ES version and will be fine.