### PR TITLE
loosen lodash dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "webpack": "1.12.13"
   },
   "dependencies": {
-    "lodash": "4.9.0"
+    "lodash": "^4.9.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
I added ^

The reasoning here is we're using this module in AWS Lambda, where total deployed size is pretty important. We can make a more complicated process that would, for example `rm -rf` this modules installation of lodash during our build/deploy, but I'd prefer to just let `npm dedupe` do its thing?