### PR TITLE
fix: add a minimum_should_match even with a single or filter

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -90,7 +90,7 @@ export function toBool (filters) {
   }
   if (
     unwrapped.minimum_should_match &&
-    filters.or.length > 1
+    filters.or.length >= 1
   ) {
     cleaned.minimum_should_match = unwrapped.minimum_should_match
   }

--- a/test/index.js
+++ b/test/index.js
@@ -766,8 +766,33 @@ test('bodybuilder | minimum_should_match query and filter', (t) => {
         filter: {
           bool: {
             should: [
-              {term: {user: 'kimchy'}},
-              {term: {user: 'tony'}}
+                { term: { user: 'kimchy' } },
+                { term: { user: 'tony' } }
+              ],
+              minimum_should_match: 1
+            }
+          }
+        }
+      }
+    })
+})
+
+test('bodybuilder | minimum_should_match with only one filter', (t) => {
+  t.plan(1)
+
+  const result = bodyBuilder()
+    .orFilter('terms', 'user', ['kimchy', 'tony'])
+    .filterMinimumShouldMatch(1)
+    .build()
+
+  t.deepEqual(result,
+    {
+      query: {
+        bool: {
+          filter: {
+            bool: {
+              should: [
+                { terms: { user: ['kimchy', 'tony'] } },
             ],
             minimum_should_match: 1
           }

--- a/test/query-builder.js
+++ b/test/query-builder.js
@@ -657,24 +657,6 @@ test('queryBuilder | or', (t) => {
   })
 })
 
-test('queryBuilder | minimum_should_match with one query ignores minimum', (t) => {
-  t.plan(1)
-
-  const result = queryBuilder()
-    .orQuery('term', 'status', 'alert')
-    .queryMinimumShouldMatch(2)
-
-  t.deepEqual(result.getQuery(), {
-    bool: {
-      should: [{
-        term: {
-          status: 'alert'
-        }
-      }]
-    }
-  })
-})
-
 test('queryBuilder | minimum_should_match with multiple combination', (t) => {
     t.plan(1)
 


### PR DESCRIPTION
The code was trying to be smart when it shouldn't have...

The problem is that it's atually quite reasonable to use a `.filterMinimumShouldMatch` with a `terms` filter, even if that's the only `should` clause.

I've removed the test that checked for the old behaviour and added a new one.

While this does in some cases change the output of bodybuilder, I'd expect that if anything it _fixes_ queries.