### PR TITLE
Types aren't included anymore

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "browser/",
     "lib/",
     "src/",
-    "bodybuilder.d.ts",
+    "types/*.d.ts",
     "repl.js"
   ],
   "scripts": {


### PR DESCRIPTION
TypeScript types aren't included anymore in the npm package since my last PR, this fixes it