### PR TITLE
extends textarea CSS website documentation

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -91,7 +91,7 @@ body {
 
 .CodeMirror {
   background-color: #F7F7F7;
-  height: 50%;
+  height: 100%;
   max-height: 800px;
 }
 


### PR DESCRIPTION
Thanks a lot for this awesome lib!
The goal of this PT is to avoid painful scrolling in https://bodybuilder.js.org textarea, there is maybe a reason why it has been put at 50% but I did not find any 🤔

## BEFORE 

https://bodybuilder.js.org translator
![image](https://user-images.githubusercontent.com/44810672/91485909-8c415480-e879-11ea-8d5c-30d3e4d9bbe0.png)

## AFTER
![image](https://user-images.githubusercontent.com/44810672/91486019-ada24080-e879-11ea-8d65-5a95232621fc.png)
