### PR TITLE
feat: add suggest builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,44 @@ var body = bodybuilder().aggregation('terms', 'code', {
 //}
 ```
 
-### Combining queries, filters, and aggregations
+### Suggestions
+
+```js
+bodybuilder().suggest([arguments])
+```
+
+Creates a `phrase` or `term` suggestion.
+
+#### Arguments
+
+The specific arguments depend on the type of aggregation, but typically follow
+this pattern:
+
+* `sugestionType` - This can be either `phrase` or `term`.
+* `fieldToAggregate` - The name of the field in your index to suggest on.
+* `options` - An object of fields to include in the suggestions.
+  * `text` - The query to run on our suggest field.
+  * `name` - A custom name for the suggest clause.
+  * `analyzer` - The name of an analyzer to run on a suggestion.
+  * ... other suggest specific options, see [typings]('./bodybuilder.d.ts') or the [ElasticSearch suggest docs](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-suggesters.html) for more info
+
+
+
+```js
+var body = bodybuilder().suggest('term', 'user', { text: 'kimchy', 'name': 'user_suggest'}).build()
+// body == {
+//   aggregations: {
+//     user_suggest: {
+//       text: 'kimchy',
+//       term: {
+//         field: 'user'
+//       }
+//     }
+//   }
+// }
+```
+
+### Combining queries, filters, aggregations, and suggestions
 
 Multiple queries and filters are merged using the boolean query or filter (see
 [Combining Filters](https://www.elastic.co/guide/en/elasticsearch/guide/current/combining-filters.html)).
@@ -191,6 +228,7 @@ var body = bodybuilder()
   .orFilter('term', 'user', 'johnny')
   .notFilter('term', 'user', 'cassie')
   .aggregation('terms', 'user')
+  .suggest('term', 'user' { text: 'kimchy' })
   .build()
 
 // body == {
@@ -222,6 +260,12 @@ var body = bodybuilder()
 //       terms: {
 //         field: 'user'
 //       }
+//     }
+//   }
+//   suggest_term_user: {
+//     text: 'kimchy',
+//     term: {
+//       field: 'user'
 //     }
 //   }
 // }

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ Creates a `phrase` or `term` suggestion.
 The specific arguments depend on the type of aggregation, but typically follow
 this pattern:
 
-* `sugestionType` - This can be either `phrase` or `term`.
+* `suggestionType` - This can be either `phrase` or `term`.
 * `fieldToAggregate` - The name of the field in your index to suggest on.
 * `options` - An object of fields to include in the suggestions.
   * `text` - The query to run on our suggest field.

--- a/bodybuilder.d.ts
+++ b/bodybuilder.d.ts
@@ -344,7 +344,7 @@ declare namespace bodybuilder {
 	 * @field text Text to suggest on
 	 */
 	export interface SuggestOptions {
-		text: string;
+		text?: string;
 		analyzer?: string;
 		name?: string;
 	}
@@ -361,7 +361,7 @@ declare namespace bodybuilder {
 		suggest<
 			SuggestT extends 'term' | 'phrase',
 		>
-			(type: SuggestT, field: string, options: DynamicSuggestOption<SuggestT>): B;
+			(type: SuggestT, field: string, options?: DynamicSuggestOption<SuggestT>): B;
 		getSuggestions(): object;
 	}
 

--- a/bodybuilder.d.ts
+++ b/bodybuilder.d.ts
@@ -335,11 +335,24 @@ declare namespace bodybuilder {
 		getRawAggregations(): object;
 	}
 
+	export interface SuggestOptions {
+		name: string,
+		text: string,
+		offset?: number,
+		length?: number,
+		options?: object[],
+	}
+	export interface SuggestionBuilder<B> {
+		suggest(type: string, field: string, options: SuggestOptions): B
+		getSuggestion(): object;
+	}
+
 	export interface Bodybuilder
 		extends Object,
 			QueryBuilder<Bodybuilder>,
 			FilterBuilder<Bodybuilder>,
-			AggregationBuilder<Bodybuilder> {
+			AggregationBuilder<Bodybuilder>,
+			SuggestionBuilder<Bodybuilder> {
 		sort(field: string): Bodybuilder;
 		sort(field: string, direction: string): Bodybuilder;
 		sort(field: string, body: object): Bodybuilder;

--- a/bodybuilder.d.ts
+++ b/bodybuilder.d.ts
@@ -335,12 +335,16 @@ declare namespace bodybuilder {
 		getRawAggregations(): object;
 	}
 
+	/**
+	 * Options to build a suggestion.
+	 *
+	 * @interface SuggestOptions
+	 * @field name A custom name for the suggestion, defaults to suggest_<type>_<field>.
+	 * @field text Text to suggest on
+	 */
 	export interface SuggestOptions {
-		name: string,
 		text: string,
-		offset?: number,
-		length?: number,
-		options?: object[],
+		name?: string,
 	}
 	export interface SuggestionBuilder<B> {
 		suggest(type: string, field: string, options: SuggestOptions): B

--- a/bodybuilder.d.ts
+++ b/bodybuilder.d.ts
@@ -349,13 +349,19 @@ declare namespace bodybuilder {
 		name?: string;
 	}
 
+	export interface TermSuggestOptions extends SuggestOptions {}
 	export interface PhraseSuggestOptions extends SuggestOptions {
 		size?: number;
 		gram_size?: number;	
 	}
+
+	export type DynamicSuggestOption<T> = T extends "term" ? TermSuggestOptions : PhraseSuggestOptions;
+
 	export interface SuggestionBuilder<B> {
-		termSuggest(field: string, options: SuggestOptions): B;
-		phraseSuggest(field: string, options: PhraseSuggestOptions): B;
+		suggest<
+			SuggestT extends 'term' | 'phrase',
+		>
+			(type: SuggestT, field: string, options: DynamicSuggestOption<SuggestT>): B;
 		getSuggestions(): object;
 	}
 

--- a/bodybuilder.d.ts
+++ b/bodybuilder.d.ts
@@ -340,14 +340,22 @@ declare namespace bodybuilder {
 	 *
 	 * @interface SuggestOptions
 	 * @field name A custom name for the suggestion, defaults to suggest_<type>_<field>.
+	 * @field name Name of predefined analyzer to use on suggest
 	 * @field text Text to suggest on
 	 */
 	export interface SuggestOptions {
-		text: string,
-		name?: string,
+		text: string;
+		analyzer?: string;
+		name?: string;
+	}
+
+	export interface PhraseSuggestOptions extends SuggestOptions {
+		size?: number;
+		gram_size?: number;	
 	}
 	export interface SuggestionBuilder<B> {
-		suggest(type: string, field: string, options: SuggestOptions): B
+		termSuggest(field: string, options: SuggestOptions): B;
+		phraseSuggest(field: string, options: PhraseSuggestOptions): B;
 		getSuggestions(): object;
 	}
 

--- a/bodybuilder.d.ts
+++ b/bodybuilder.d.ts
@@ -348,7 +348,7 @@ declare namespace bodybuilder {
 	}
 	export interface SuggestionBuilder<B> {
 		suggest(type: string, field: string, options: SuggestOptions): B
-		getSuggestion(): object;
+		getSuggestions(): object;
 	}
 
 	export interface Bodybuilder

--- a/bodybuilder.d.ts
+++ b/bodybuilder.d.ts
@@ -339,8 +339,8 @@ declare namespace bodybuilder {
 	 * Options to build a suggestion.
 	 *
 	 * @interface SuggestOptions
+	 * @field analyzer Name of predefined analyzer to use on suggest
 	 * @field name A custom name for the suggestion, defaults to suggest_<type>_<field>.
-	 * @field name Name of predefined analyzer to use on suggest
 	 * @field text Text to suggest on
 	 */
 	export interface SuggestOptions {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7730,9 +7730,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.7.2.tgz",
-      "integrity": "sha512-p5TCYZDAO0m4G344hD+wx/LATebLWZNkkh2asWUFqSsD2OrDNhbAHuSjobrmsUmdzjJjEeZVU9g1h3O6vpstnw==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
+      "integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "tap-spec": "4.1.1",
     "tape": "4.8.0",
     "tape-watch": "2.3.0",
-    "typescript": "2.7.2",
+    "typescript": "^4.1.3",
     "webpack": "1.12.13"
   },
   "dependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ import _ from 'lodash'
 import queryBuilder from './query-builder'
 import filterBuilder from './filter-builder'
 import aggregationBuilder from './aggregation-builder'
+import suggestionBuilder from './suggestion-builder'
 import { sortMerge } from './utils'
 
 /**
@@ -60,9 +61,10 @@ import { sortMerge } from './utils'
  * @param  {Object} newQueries Queries to initialise with
  * @param  {Object} newFilters Filters to initialise with
  * @param  {Object} newAggregations Aggregations to initialise with
+ * @param  {Object} newSuggestions Suggestions to initialise with
  * @return {bodybuilder} Builder.
  */
-export default function bodybuilder (newBody, newQueries, newFilters, newAggregations) {
+export default function bodybuilder (newBody, newQueries, newFilters, newAggregations, newSuggestions) {
   let body = newBody || {}
 
   return Object.assign(
@@ -225,7 +227,8 @@ export default function bodybuilder (newBody, newQueries, newFilters, newAggrega
     },
     queryBuilder(undefined, newQueries),
     filterBuilder(undefined, newFilters),
-    aggregationBuilder(newAggregations)
+    aggregationBuilder(newAggregations),
+    suggestionBuilder(newSuggestions)
   )
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -196,12 +196,13 @@ export default function bodybuilder (newBody, newQueries, newFilters, newAggrega
         const queries = this.getQuery()
         const filters = this.getFilter()
         const aggregations = this.getAggregations()
+        const suggestions = this.getSuggestions()
 
         if (version === 'v1') {
           return _buildV1(body, queries, filters, aggregations)
         }
 
-        return _build(body, queries, filters, aggregations)
+        return _build(body, queries, filters, aggregations, suggestions)
       },
 
       /**
@@ -220,8 +221,9 @@ export default function bodybuilder (newBody, newQueries, newFilters, newAggrega
         const queries = this.getRawQuery()
         const filters = this.getRawFilter()
         const aggregations = this.getRawAggregations()
+        const suggestions = this.getSuggestions()
 
-        return bodybuilder(...[body, queries, filters, aggregations].map(obj => _.cloneDeep(obj)))
+        return bodybuilder(...[body, queries, filters, aggregations, suggestions].map(obj => _.cloneDeep(obj)))
       }
 
     },
@@ -252,7 +254,7 @@ function _buildV1(body, queries, filters, aggregations) {
   return clonedBody
 }
 
-function _build(body, queries, filters, aggregations) {
+function _build(body, queries, filters, aggregations, suggestions) {
   let clonedBody = _.cloneDeep(body)
 
   if (!_.isEmpty(filters)) {
@@ -271,6 +273,10 @@ function _build(body, queries, filters, aggregations) {
 
   if (!_.isEmpty(aggregations)) {
     _.set(clonedBody, 'aggs', aggregations)
+  }
+
+  if (!_.isEmpty(suggestions)) {
+    _.set(clonedBody, 'suggest', suggestions)
   }
 
   return clonedBody

--- a/src/suggestion-builder.js
+++ b/src/suggestion-builder.js
@@ -33,27 +33,54 @@ export default function suggestionBuilder(newSuggestion) {
         /**
          * Add an suggestion clause to the query body.
          *
-         * @param  {string|Object} type      Name of the suggestion type, such as `'term'`.
          * @param  {string}        field     Name of the field to suggest on.
          * @param  {Object}        [options] (optional) Additional options to
          *                                   include in the aggregation.
          *                         [options.text ] text query to run on suggest
          *                         [options.name ] pass a custom name to the function
+         *                         [options.analyzer ] name of predefined analyzer to use on suggest
          * 
          * @return {bodybuilder} Builder.
          *
          * @example
          * bodybuilder()
-         *   .suggest('term', 'price', { text: 'test' })
+         *   .suggest('price', { text: 'test' })
          *   .build()
          *
          * bodybuilder()
-         *   .suggest('term', 'price', { text: 'test', name: 'custom name' })
+         *   .suggest('price', { text: 'test', name: 'custom name' })
          *   .build()
          *
          */
-        suggest(...args) {
-            makeSuggestion(...args)
+        termSuggest(...args) {
+            makeSuggestion('term', ...args)
+            return this
+        },
+        /**
+         * Add an suggestion clause to the query body.
+         *
+         * @param  {string}        field     Name of the field to suggest on.
+         * @param  {Object}        [options] (optional) Additional options to
+         *                                   include in the aggregation.
+         *                         [options.text ] text query to run on suggest
+         *                         [options.name ] pass a custom name to the function
+         *                         [options.analyzer ] name of predefined analyzer to use on suggest
+         *                         [options.size ] The number of candidates that are generated for each individual query term
+         *                         [options.gram_size ] The max number of n-grams per field
+         * @return {bodybuilder} Builder.
+         *
+         * @example
+         * bodybuilder()
+         *   .suggest('price', { text: 'test' })
+         *   .build()
+         *
+         * bodybuilder()
+         *   .suggest('price', { text: 'test', name: 'custom name' })
+         *   .build()
+         *
+         */
+        phraseSuggest(...args) {
+            makeSuggestion('phrase', ...args)
             return this
         },
         getSuggestions() {

--- a/src/suggestion-builder.js
+++ b/src/suggestion-builder.js
@@ -1,64 +1,66 @@
 import _ from 'lodash'
 import { buildClause } from './utils'
 
-export default function suggestionBuilder (newSuggestion) {
-  let suggestion = _.isEmpty(newSuggestion) ? {} : newSuggestion
+export default function suggestionBuilder(newSuggestion) {
+    let suggestions = _.isEmpty(newSuggestion) ? {} : newSuggestion
 
-  function makeSuggestion (type, field, options) {
-    let suggestName
-    const { name, text } = options
+    function makeSuggestion(type, field, options) {
+        let suggestName
+        const { name, text } = options
 
-    if (name) {
-        suggestName = name
-        _.unset(options, 'name')
-    } else {
-        suggestName = `suggest_${type}_${field}`
+        if (name) {
+            suggestName = name
+            _.unset(options, 'name')
+        } else {
+            suggestName = `suggest_${type}_${field}`
+        }
+
+        if (text) {
+            _.unset(options, 'text')
+        }
+
+        const innerClause = Object.assign({}, {
+            text,
+            [type]: buildClause(field, null, options)
+        })
+
+        Object.assign(suggestions, {
+            [suggestName]: innerClause
+        })
     }
 
-    if (text) {
-        _.unset(options, 'text')
+    return {
+        /**
+         * Add an suggestion clause to the query body.
+         *
+         * @param  {string|Object} type      Name of the suggestion type, such as `'term'`.
+         * @param  {string}        field     Name of the field to suggest on.
+         * @param  {Object}        [options] (optional) Additional options to
+         *                                   include in the aggregation.
+         *                         [options.text ] text query to run on suggest
+         *                         [options.name ] pass a custom name to the function
+         * 
+         * @return {bodybuilder} Builder.
+         *
+         * @example
+         * bodybuilder()
+         *   .suggest('term', 'price', { text: 'test' })
+         *   .build()
+         *
+         * bodybuilder()
+         *   .suggest('term', 'price', { text: 'test', name: 'custom name' })
+         *   .build()
+         *
+         */
+        suggest(...args) {
+            makeSuggestion(...args)
+            return this
+        },
+        getSuggestions() {
+            return suggestions
+        },
+        hasSuggestions() {
+            return !_.isEmpty(suggestions)
+        },
     }
-
-    const innerClause = Object.assign({}, {
-      text,
-      [type]: buildClause(field, null, options)
-    })
-
-    Object.assign(suggestion, {
-      [suggestName]: innerClause
-    })
-  }
-
-  return {
-          /**
-     * Add an suggestion clause to the query body.
-     *
-     * @param  {string|Object} type      Name of the suggestion type, such as
-     *                                   `'sum'` or `'terms'`.
-     * @param  {string}        field     Name of the field to suggest on.
-     * @param  {Object}        [options] (optional) Additional options to
-     *                                   include in the aggregation.
-     *                         [options.text ] text query to run on suggest
-     *                         [options.name ] pass a custom name to the function
-     * 
-     * @return {bodybuilder} Builder.
-     *
-     * @example
-     * bodybuilder()
-     *   .suggest('max', 'price', { text: 'test' })
-     *   .build()
-     *
-     * bodybuilder()
-     *   .suggest('max', 'price', { text: 'test', name: 'custom name' })
-     *   .build()
-     *
-     */
-    suggest (...args) {
-      makeSuggestion(...args)
-      return this
-    },
-    getSuggestion () {
-        return suggestion
-    },
-  }
 }

--- a/src/suggestion-builder.js
+++ b/src/suggestion-builder.js
@@ -4,7 +4,7 @@ import { buildClause } from './utils'
 export default function suggestionBuilder(newSuggestion) {
     let suggestions = _.isEmpty(newSuggestion) ? {} : newSuggestion
 
-    function makeSuggestion(type, field, options) {
+    function makeSuggestion(type, field, options = {}) {
         let suggestName
         const { name, text } = options
 
@@ -15,14 +15,14 @@ export default function suggestionBuilder(newSuggestion) {
             suggestName = `suggest_${type}_${field}`
         }
 
+        let innerClause = {}
+
         if (text) {
             _.unset(options, 'text')
+            innerClause.text = text
         }
 
-        const innerClause = Object.assign({}, {
-            text,
-            [type]: buildClause(field, null, options)
-        })
+        innerClause[type] = buildClause(field, null, options)
 
         Object.assign(suggestions, {
             [suggestName]: innerClause

--- a/src/suggestion-builder.js
+++ b/src/suggestion-builder.js
@@ -5,17 +5,19 @@ export default function suggestionBuilder (newSuggestion) {
   let suggestion = _.isEmpty(newSuggestion) ? {} : newSuggestion
 
   function makeSuggestion (type, field, options) {
-
+    let suggestName
     const { name, text } = options
 
     if (name) {
+        suggestName = name
         _.unset(options, 'name')
+    } else {
+        suggestName = `suggest_${type}_${field}`
     }
 
     if (text) {
         _.unset(options, 'text')
     }
-
 
     const innerClause = Object.assign({}, {
       text,
@@ -23,11 +25,34 @@ export default function suggestionBuilder (newSuggestion) {
     })
 
     Object.assign(suggestion, {
-      [name]: innerClause
+      [suggestName]: innerClause
     })
   }
 
   return {
+          /**
+     * Add an suggestion clause to the query body.
+     *
+     * @param  {string|Object} type      Name of the suggestion type, such as
+     *                                   `'sum'` or `'terms'`.
+     * @param  {string}        field     Name of the field to suggest on.
+     * @param  {Object}        [options] (optional) Additional options to
+     *                                   include in the aggregation.
+     *                         [options.text ] text query to run on suggest
+     *                         [options.name ] pass a custom name to the function
+     * 
+     * @return {bodybuilder} Builder.
+     *
+     * @example
+     * bodybuilder()
+     *   .suggest('max', 'price', { text: 'test' })
+     *   .build()
+     *
+     * bodybuilder()
+     *   .suggest('max', 'price', { text: 'test', name: 'custom name' })
+     *   .build()
+     *
+     */
     suggest (...args) {
       makeSuggestion(...args)
       return this

--- a/src/suggestion-builder.js
+++ b/src/suggestion-builder.js
@@ -52,35 +52,8 @@ export default function suggestionBuilder(newSuggestion) {
          *   .build()
          *
          */
-        termSuggest(...args) {
-            makeSuggestion('term', ...args)
-            return this
-        },
-        /**
-         * Add an suggestion clause to the query body.
-         *
-         * @param  {string}        field     Name of the field to suggest on.
-         * @param  {Object}        [options] (optional) Additional options to
-         *                                   include in the aggregation.
-         *                         [options.text ] text query to run on suggest
-         *                         [options.name ] pass a custom name to the function
-         *                         [options.analyzer ] name of predefined analyzer to use on suggest
-         *                         [options.size ] The number of candidates that are generated for each individual query term
-         *                         [options.gram_size ] The max number of n-grams per field
-         * @return {bodybuilder} Builder.
-         *
-         * @example
-         * bodybuilder()
-         *   .suggest('price', { text: 'test' })
-         *   .build()
-         *
-         * bodybuilder()
-         *   .suggest('price', { text: 'test', name: 'custom name' })
-         *   .build()
-         *
-         */
-        phraseSuggest(...args) {
-            makeSuggestion('phrase', ...args)
+        suggest(...args) {
+            makeSuggestion(...args)
             return this
         },
         getSuggestions() {

--- a/src/suggestion-builder.js
+++ b/src/suggestion-builder.js
@@ -1,0 +1,39 @@
+import _ from 'lodash'
+import { buildClause } from './utils'
+
+export default function suggestionBuilder (newSuggestion) {
+  let suggestion = _.isEmpty(newSuggestion) ? {} : newSuggestion
+
+  function makeSuggestion (type, field, options) {
+
+    const { name, text } = options
+
+    if (name) {
+        _.unset(options, 'name')
+    }
+
+    if (text) {
+        _.unset(options, 'text')
+    }
+
+
+    const innerClause = Object.assign({}, {
+      text,
+      [type]: buildClause(field, null, options)
+    })
+
+    Object.assign(suggestion, {
+      [name]: innerClause
+    })
+  }
+
+  return {
+    suggest (...args) {
+      makeSuggestion(...args)
+      return this
+    },
+    getSuggestion () {
+        return suggestion
+    },
+  }
+}

--- a/src/suggestion-builder.js
+++ b/src/suggestion-builder.js
@@ -31,11 +31,11 @@ export default function suggestionBuilder(newSuggestion) {
 
     return {
         /**
-         * Add an suggestion clause to the query body.
+         * Add a suggestion clause to the query body.
          *
          * @param  {string}        field     Name of the field to suggest on.
          * @param  {Object}        [options] (optional) Additional options to
-         *                                   include in the aggregation.
+         *                                   include in the suggestion clause.
          *                         [options.text ] text query to run on suggest
          *                         [options.name ] pass a custom name to the function
          *                         [options.analyzer ] name of predefined analyzer to use on suggest
@@ -44,11 +44,11 @@ export default function suggestionBuilder(newSuggestion) {
          *
          * @example
          * bodybuilder()
-         *   .suggest('price', { text: 'test' })
+         *   .suggest('term', price', { text: 'test' })
          *   .build()
          *
          * bodybuilder()
-         *   .suggest('price', { text: 'test', name: 'custom name' })
+         *   .suggest('phrase', 'price', { text: 'test', name: 'custom name' })
          *   .build()
          *
          */

--- a/test/index.js
+++ b/test/index.js
@@ -657,7 +657,8 @@ test('bodyBuilder should combine queries, filters, aggregations, suggestions', (
     .orFilter('term', 'user', 'johnny')
     .notFilter('term', 'user', 'cassie')
     .aggregation('terms', 'user')
-    .suggest('term', 'user', { text: 'kimchy', name: 'user' } )
+    .termSuggest('user', { text: 'kimchy', name: 'userTerm' } )
+    .phraseSuggest('user', { text: 'kimchy', name: 'userPhrase' })
     .build()
 
   t.deepEqual(result, {
@@ -692,12 +693,18 @@ test('bodyBuilder should combine queries, filters, aggregations, suggestions', (
       }
     },
     suggest: {
-      user: {
+      userTerm: {
           text: 'kimchy',
           term: {
               field: 'user',
           }
-      }
+      },
+      userPhrase: {
+        text: 'kimchy',
+        phrase: {
+            field: 'user',
+        }
+    }
   }
   })
 })

--- a/test/index.js
+++ b/test/index.js
@@ -151,7 +151,7 @@ test('bodyBuilder should build a filtered query for version 2.x', (t) => {
           }
         },
         filter: {
-          term: {user: 'kimchy'}
+          term: { user: 'kimchy' }
         }
       }
     }
@@ -175,29 +175,29 @@ test('bodyBuilder should sort with default sort direction', (t) => {
 })
 
 test('bodyBuilder should handle string fields in multi-sort', (t) => {
-    t.plan(1)
+  t.plan(1)
 
-    const result = bodyBuilder()
-        .sort([
-            { categories: 'desc' },
-            { content: 'desc' },
-            'content'
-        ]).build()
+  const result = bodyBuilder()
+    .sort([
+      { categories: 'desc' },
+      { content: 'desc' },
+      'content'
+    ]).build()
 
-    t.deepEqual(result, {
-        sort: [
-            {
-                categories: {
-                    order: 'desc'
-                }
-            },
-            {
-                content: {
-                    order:'asc'
-                }
-            }
-        ]
-    })
+  t.deepEqual(result, {
+    sort: [
+      {
+        categories: {
+          order: 'desc'
+        }
+      },
+      {
+        content: {
+          order: 'asc'
+        }
+      }
+    ]
+  })
 })
 
 
@@ -224,12 +224,12 @@ test('bodyBuilder should not de-depude _geo_distance', (t) => {
       }
     }
   ])
-  .sort([
-    { categories: 'desc' },
-    { content: 'desc' },
-    { content: 'asc' }
-  ])
-  .build()
+    .sort([
+      { categories: 'desc' },
+      { content: 'desc' },
+      { content: 'asc' }
+    ])
+    .build()
 
   t.deepEqual(result, {
     sort: [
@@ -264,7 +264,7 @@ test('bodyBuilder should not de-depude _geo_distance', (t) => {
       },
       {
         content: {
-          order:'asc'
+          order: 'asc'
         }
       }
     ]
@@ -296,32 +296,34 @@ test('bodyBuilder should not de-depude nested sort', (t) => {
       }
     ])
     .sort([
-    { 'nested_entity.name': {
-        order: "desc",
-        nested: {
-          path: "nested_entity",
-          filter: {
-            term: { "nested_entity.subfield.text" : "text1" }
+      {
+        'nested_entity.name': {
+          order: "desc",
+          nested: {
+            path: "nested_entity",
+            filter: {
+              term: { "nested_entity.subfield.text": "text1" }
+            }
+          }
+        }
+      },
+      {
+        'nested_entity.name': {
+          order: "desc",
+          nested: {
+            path: "nested_entity",
+            filter: {
+              term: { "nested_entity.subfield.text": "text2" }
+            }
           }
         }
       }
-    },
-    { 'nested_entity.name': {
-        order: "desc",
-        nested: {
-          path: "nested_entity",
-          filter: {
-            term: { "nested_entity.subfield.text" : "text2" }
-          }
-        }
-      }
-    }
-  ])
+    ])
     .sort([
-    { categories: 'desc' },
-    { content: 'desc' },
-    { content: 'asc' }
-  ])
+      { categories: 'desc' },
+      { content: 'desc' },
+      { content: 'asc' }
+    ])
     .build()
 
   t.deepEqual(result, {
@@ -350,7 +352,7 @@ test('bodyBuilder should not de-depude nested sort', (t) => {
           nested: {
             path: 'nested_entity',
             filter: {
-              term: { 'nested_entity.subfield.text' : 'text1' }
+              term: { 'nested_entity.subfield.text': 'text1' }
             }
           }
         }
@@ -361,7 +363,7 @@ test('bodyBuilder should not de-depude nested sort', (t) => {
           nested: {
             path: 'nested_entity',
             filter: {
-              term: { 'nested_entity.subfield.text' : 'text2' }
+              term: { 'nested_entity.subfield.text': 'text2' }
             }
           }
         }
@@ -373,7 +375,7 @@ test('bodyBuilder should not de-depude nested sort', (t) => {
       },
       {
         content: {
-          order:'asc'
+          order: 'asc'
         }
       }
     ]
@@ -403,7 +405,7 @@ test('bodyBuilder should set size on body', (t) => {
 test('bodyBuilder should set any key-value on body', (t) => {
   t.plan(1)
 
-  const result = bodyBuilder().rawOption('a', {b: 'c'}).build()
+  const result = bodyBuilder().rawOption('a', { b: 'c' }).build()
 
   t.deepEqual(result, {
     a: { b: 'c' }
@@ -425,11 +427,11 @@ test('bodyBuilder should build query with field and value', (t) => {
 test('bodyBuilder should build query with field and object value', (t) => {
   t.plan(1)
 
-  const result = bodyBuilder().query('range', 'date', {gt: 'now-1d'})
+  const result = bodyBuilder().query('range', 'date', { gt: 'now-1d' })
 
   t.deepEqual(result.getQuery(), {
     range: {
-      date: {gt: 'now-1d'}
+      date: { gt: 'now-1d' }
     }
   })
 })
@@ -437,7 +439,7 @@ test('bodyBuilder should build query with field and object value', (t) => {
 test('bodyBuilder should build query with more options', (t) => {
   t.plan(1)
 
-  const result = bodyBuilder().query('geo_distance', 'point', {lat: 40, lon: 20}, {distance: '12km'})
+  const result = bodyBuilder().query('geo_distance', 'point', { lat: 40, lon: 20 }, { distance: '12km' })
 
   t.deepEqual(result.getQuery(), {
     geo_distance: {
@@ -470,8 +472,8 @@ test('bodyBuilder should build nested queries', (t) => {
 test('bodyBuilder should nest bool-merged queries', (t) => {
   t.plan(1)
 
-  const result = bodyBuilder().query('nested', 'path', 'obj1', {score_mode: 'avg'}, (q) => {
-    return q.query('match', 'obj1.name', 'blue').query('range', 'obj1.count', {gt: 5})
+  const result = bodyBuilder().query('nested', 'path', 'obj1', { score_mode: 'avg' }, (q) => {
+    return q.query('match', 'obj1.name', 'blue').query('range', 'obj1.count', { gt: 5 })
   })
 
   t.deepEqual(result.getQuery(), {
@@ -482,10 +484,10 @@ test('bodyBuilder should nest bool-merged queries', (t) => {
         bool: {
           must: [
             {
-              match: {'obj1.name': 'blue'}
+              match: { 'obj1.name': 'blue' }
             },
             {
-              range: {'obj1.count': {gt: 5}}
+              range: { 'obj1.count': { gt: 5 } }
             }
           ]
         }
@@ -499,11 +501,11 @@ test('bodyBuilder should make this chained nested query', (t) => {
 
   const result = bodyBuilder()
     .query('match', 'title', 'eggs')
-    .query('nested', 'path', 'comments', {score_mode: 'max'} , (q) => {
+    .query('nested', 'path', 'comments', { score_mode: 'max' }, (q) => {
       return q
         .query('match', 'comments.name', 'john')
         .query('match', 'comments.age', 28)
-  })
+    })
 
   t.deepEqual(result.getQuery(), {
     bool: {
@@ -624,14 +626,14 @@ test('bodyBuilder should combine queries, filters, aggregations', (t) => {
         filter: {
           bool: {
             must: [
-              {term: {user: 'kimchy'}},
-              {term: {user: 'herald'}}
+              { term: { user: 'kimchy' } },
+              { term: { user: 'herald' } }
             ],
             should: [
-              {term: {user: 'johnny'}}
+              { term: { user: 'johnny' } }
             ],
             must_not: [
-              {term: {user: 'cassie'}}
+              { term: { user: 'cassie' } }
             ]
           }
         }
@@ -657,7 +659,7 @@ test('bodyBuilder should combine queries, filters, aggregations, suggestions', (
     .orFilter('term', 'user', 'johnny')
     .notFilter('term', 'user', 'cassie')
     .aggregation('terms', 'user')
-    .suggest('term', 'user', { text: 'kimchy', name: 'userTerm' } )
+    .suggest('term', 'user', { text: 'kimchy', name: 'userTerm' })
     .suggest('phrase', 'user', { text: 'kimchy', name: 'userPhrase' })
     .build()
 
@@ -672,14 +674,14 @@ test('bodyBuilder should combine queries, filters, aggregations, suggestions', (
         filter: {
           bool: {
             must: [
-              {term: {user: 'kimchy'}},
-              {term: {user: 'herald'}}
+              { term: { user: 'kimchy' } },
+              { term: { user: 'herald' } }
             ],
             should: [
-              {term: {user: 'johnny'}}
+              { term: { user: 'johnny' } }
             ],
             must_not: [
-              {term: {user: 'cassie'}}
+              { term: { user: 'cassie' } }
             ]
           }
         }
@@ -694,18 +696,18 @@ test('bodyBuilder should combine queries, filters, aggregations, suggestions', (
     },
     suggest: {
       userTerm: {
-          text: 'kimchy',
-          term: {
-              field: 'user',
-          }
+        text: 'kimchy',
+        term: {
+          field: 'user',
+        }
       },
       userPhrase: {
         text: 'kimchy',
         phrase: {
-            field: 'user',
+          field: 'user',
         }
+      }
     }
-  }
   })
 })
 
@@ -767,24 +769,24 @@ test('bodybuilder | or filter', (t) => {
   t.plan(1)
 
   const result = bodyBuilder().filter('or', [
-    {term: {user: 'kimchy'}},
-    {term: {user: 'tony'}}
+    { term: { user: 'kimchy' } },
+    { term: { user: 'tony' } }
   ])
-  .build()
+    .build()
 
   t.deepEqual(result,
-  {
-    query: {
-      bool: {
-        filter: {
-          or: [
-            {term: {user: 'kimchy'}},
-            {term: {user: 'tony'}}
-          ]
+    {
+      query: {
+        bool: {
+          filter: {
+            or: [
+              { term: { user: 'kimchy' } },
+              { term: { user: 'tony' } }
+            ]
+          }
         }
       }
-    }
-  })
+    })
 })
 
 test('bodybuilder | dynamic filter', t => {
@@ -796,24 +798,28 @@ test('bodybuilder | dynamic filter', t => {
     .build()
 
   t.deepEqual(result,
-  {
-    query: { bool: { filter: {
-      bool: {
-        must: [
-          {
-            constant_score: {
-              filter: {
-                term: {
-                  user: 'kimchy'
-                }
-              }
+    {
+      query: {
+        bool: {
+          filter: {
+            bool: {
+              must: [
+                {
+                  constant_score: {
+                    filter: {
+                      term: {
+                        user: 'kimchy'
+                      }
+                    }
+                  }
+                },
+                { term: { message: 'this is a test' } }
+              ]
             }
-          },
-          { term: { message: 'this is a test' } }
-        ]
+          }
+        }
       }
-    } } }
-  })
+    })
 })
 
 test('bodybuilder | complex dynamic filter', t => {
@@ -838,54 +844,76 @@ test('bodybuilder | complex dynamic filter', t => {
     .build()
 
   t.deepEqual(result, {
-    query: { bool: { filter: { bool: { should: [
-      {
-        bool: { must: [
-          { terms: { tags: ['Popular'] } },
-          { terms: { brands: ['A', 'B'] } }
-        ]}
-      },
-      {
-        bool: { must: [
-          { terms: { tags: ['Emerging'] } },
-          { terms: { brands: ['C'] } }
-        ]}
-      },
-      {
-        bool: { must: [
-          { terms: { tags: ['Rumor'] } },
-          { terms: { companies: ['A', 'C', 'D'] } }
-        ]}
+    query: {
+      bool: {
+        filter: {
+          bool: {
+            should: [
+              {
+                bool: {
+                  must: [
+                    { terms: { tags: ['Popular'] } },
+                    { terms: { brands: ['A', 'B'] } }
+                  ]
+                }
+              },
+              {
+                bool: {
+                  must: [
+                    { terms: { tags: ['Emerging'] } },
+                    { terms: { brands: ['C'] } }
+                  ]
+                }
+              },
+              {
+                bool: {
+                  must: [
+                    { terms: { tags: ['Rumor'] } },
+                    { terms: { companies: ['A', 'C', 'D'] } }
+                  ]
+                }
+              }
+            ]
+          }
+        }
       }
-    ]}}}}
+    }
   })
 
   t.deepEqual(result.query.bool.filter.bool.should, [
     {
-      bool: { must: [
-        { terms: { tags: ['Popular'] } },
-        { terms: { brands: ['A', 'B'] } }
-      ]}
+      bool: {
+        must: [
+          { terms: { tags: ['Popular'] } },
+          { terms: { brands: ['A', 'B'] } }
+        ]
+      }
     },
     {
-      bool: { must: [
-        { terms: { tags: ['Emerging'] } },
-        { terms: { brands: ['C'] } }
-      ]}
+      bool: {
+        must: [
+          { terms: { tags: ['Emerging'] } },
+          { terms: { brands: ['C'] } }
+        ]
+      }
     },
     {
-      bool: { must: [
-        { terms: { tags: ['Rumor'] } },
-        { terms: { companies: ['A', 'C', 'D'] } }
-      ]}
+      bool: {
+        must: [
+          { terms: { tags: ['Rumor'] } },
+          { terms: { companies: ['A', 'C', 'D'] } }
+        ]
+      }
     }
   ])
 
   t.deepEqual(result.query.bool.filter.bool.should[0], {
-    bool: { must: [
-      { terms: { tags: ['Popular'] } },
-      { terms: { brands: ['A', 'B'] } }
-    ]}
+    bool: {
+      must: [
+        { terms: { tags: ['Popular'] } },
+        { terms: { brands: ['A', 'B'] } }
+      ]
+    }
   })
 
 })
@@ -900,21 +928,21 @@ test('bodybuilder | minimum_should_match filter', (t) => {
     .build()
 
   t.deepEqual(result,
-  {
-    query: {
-      bool: {
-        filter: {
-          bool: {
-            should: [
-              {term: {user: 'kimchy'}},
-              {term: {user: 'tony'}}
-            ],
-            minimum_should_match: 2
+    {
+      query: {
+        bool: {
+          filter: {
+            bool: {
+              should: [
+                { term: { user: 'kimchy' } },
+                { term: { user: 'tony' } }
+              ],
+              minimum_should_match: 2
+            }
           }
         }
       }
-    }
-  })
+    })
 })
 
 test('bodybuilder | minimum_should_match with 1 filter', (t) => {
@@ -932,7 +960,7 @@ test('bodybuilder | minimum_should_match with 1 filter', (t) => {
           filter: {
             bool: {
               should: [
-                {term: {user: 'kimchy'}}
+                { term: { user: 'kimchy' } }
               ]
             }
           }
@@ -956,7 +984,7 @@ test('bodybuilder | minimum_should_match with 1 filter + override', (t) => {
           filter: {
             bool: {
               should: [
-                {term: {user: 'kimchy'}}
+                { term: { user: 'kimchy' } }
               ],
               minimum_should_match: 1
             }
@@ -976,17 +1004,17 @@ test('bodybuilder | minimum_should_match query', (t) => {
     .build()
 
   t.deepEqual(result,
-  {
-    query: {
-      bool: {
-        should: [
-          {term: {user: 'kimchy'}},
-          {term: {user: 'tony'}}
-        ],
-        minimum_should_match: 2
+    {
+      query: {
+        bool: {
+          should: [
+            { term: { user: 'kimchy' } },
+            { term: { user: 'tony' } }
+          ],
+          minimum_should_match: 2
+        }
       }
-    }
-  })
+    })
 })
 
 test('bodybuilder | minimum_should_match query and filter', (t) => {
@@ -1002,26 +1030,26 @@ test('bodybuilder | minimum_should_match query and filter', (t) => {
     .build()
 
   t.deepEqual(result,
-  {
-    query: {
-      bool: {
-        should: [
-          {term: {user: 'kimchy'}},
-          {term: {user: 'tony'}}
-        ],
-        minimum_should_match: 2,
-        filter: {
-          bool: {
-            should: [
-              {term: {user: 'kimchy'}},
-              {term: {user: 'tony'}}
-            ],
-            minimum_should_match: 1
+    {
+      query: {
+        bool: {
+          should: [
+            { term: { user: 'kimchy' } },
+            { term: { user: 'tony' } }
+          ],
+          minimum_should_match: 2,
+          filter: {
+            bool: {
+              should: [
+                { term: { user: 'kimchy' } },
+                { term: { user: 'tony' } }
+              ],
+              minimum_should_match: 1
+            }
           }
         }
       }
-    }
-  })
+    })
 })
 
 test('bodybuilder | Nested bool query with must #162', (t) => {
@@ -1070,7 +1098,7 @@ test('bodybuilder | Nested bool query with must #162', (t) => {
         }
       }
     }
-)
+  )
 })
 
 test('bodybuilder | Invalid nested bool query with more "query" #142', (t) => {

--- a/test/index.js
+++ b/test/index.js
@@ -657,8 +657,8 @@ test('bodyBuilder should combine queries, filters, aggregations, suggestions', (
     .orFilter('term', 'user', 'johnny')
     .notFilter('term', 'user', 'cassie')
     .aggregation('terms', 'user')
-    .termSuggest('user', { text: 'kimchy', name: 'userTerm' } )
-    .phraseSuggest('user', { text: 'kimchy', name: 'userPhrase' })
+    .suggest('term', 'user', { text: 'kimchy', name: 'userTerm' } )
+    .suggest('phrase', 'user', { text: 'kimchy', name: 'userPhrase' })
     .build()
 
   t.deepEqual(result, {

--- a/test/suggestion-builder.js
+++ b/test/suggestion-builder.js
@@ -5,7 +5,7 @@ import suggestionBuilder from '../src/suggestion-builder'
 test('suggestion Builder | term suggest', (t) => {
     t.plan(1)
 
-    const result = suggestionBuilder().termSuggest('products', { text: 'testing' })
+    const result = suggestionBuilder().suggest('term', 'products', { text: 'testing' })
 
     t.deepEqual(result.getSuggestions(), {
         'suggest_term_products': {
@@ -20,7 +20,7 @@ test('suggestion Builder | term suggest', (t) => {
 test('suggestion Builder | term suggest with custom name', (t) => {
     t.plan(1)
 
-    const result = suggestionBuilder().termSuggest('products', { name: 'products', text: 'testing' })
+    const result = suggestionBuilder().suggest('term', 'products', { name: 'products', text: 'testing' })
 
     t.deepEqual(result.getSuggestions(), {
         products: {
@@ -35,7 +35,7 @@ test('suggestion Builder | term suggest with custom name', (t) => {
 test('suggestion Builder | phrase suggest', (t) => {
     t.plan(1)
 
-    const result = suggestionBuilder().phraseSuggest('products', { text: 'testing' })
+    const result = suggestionBuilder().suggest('phrase', 'products', { text: 'testing' })
 
     t.deepEqual(result.getSuggestions(), {
         'suggest_phrase_products': {
@@ -50,7 +50,7 @@ test('suggestion Builder | phrase suggest', (t) => {
 test('suggestion Builder | phrase suggest with custom name', (t) => {
     t.plan(1)
 
-    const result = suggestionBuilder().phraseSuggest('products', { name: 'products', text: 'testing' })
+    const result = suggestionBuilder().suggest('phrase', 'products', { name: 'products', text: 'testing' })
 
     t.deepEqual(result.getSuggestions(), {
         products: {

--- a/test/suggestion-builder.js
+++ b/test/suggestion-builder.js
@@ -4,32 +4,30 @@ import suggestionBuilder from '../src/suggestion-builder'
 
 test('suggestion Builder | term suggest', (t) => {
     t.plan(1)
-  
-    const result = suggestionBuilder().suggest('term', 'products', { name: 'products', text: 'testing' })
-  
-    t.deepEqual(result.getSuggestion(), {
-      products: {
-        text: 'testing',
-        term: {
-          field: 'products',
-        }
-      }
-    })
-  })
 
-  test('suggestion Builder | term suggest with offset and length', (t) => {
-    t.plan(1)
-  
-    const result = suggestionBuilder().suggest('term', 'products', { name: 'products', text: 'testing', offset: 2, length: 10 })
-  
+    const result = suggestionBuilder().suggest('term', 'products', { text: 'testing' })
+
     t.deepEqual(result.getSuggestion(), {
-      products: {
-        text: 'testing',
-        term: {
-          field: 'products',
-          offset: 2,
-          length: 10
+        'suggest_term_products': {
+            text: 'testing',
+            term: {
+                field: 'products',
+            }
         }
-      }
     })
-  })
+})
+
+test('suggestion Builder | term suggest with custom name', (t) => {
+    t.plan(1)
+
+    const result = suggestionBuilder().suggest('term', 'products', { name: 'products', text: 'testing' })
+
+    t.deepEqual(result.getSuggestion(), {
+        products: {
+            text: 'testing',
+            term: {
+                field: 'products',
+            }
+        }
+    })
+})

--- a/test/suggestion-builder.js
+++ b/test/suggestion-builder.js
@@ -7,7 +7,7 @@ test('suggestion Builder | term suggest', (t) => {
 
     const result = suggestionBuilder().suggest('term', 'products', { text: 'testing' })
 
-    t.deepEqual(result.getSuggestion(), {
+    t.deepEqual(result.getSuggestions(), {
         'suggest_term_products': {
             text: 'testing',
             term: {
@@ -22,7 +22,7 @@ test('suggestion Builder | term suggest with custom name', (t) => {
 
     const result = suggestionBuilder().suggest('term', 'products', { name: 'products', text: 'testing' })
 
-    t.deepEqual(result.getSuggestion(), {
+    t.deepEqual(result.getSuggestions(), {
         products: {
             text: 'testing',
             term: {

--- a/test/suggestion-builder.js
+++ b/test/suggestion-builder.js
@@ -102,3 +102,17 @@ test('suggestion Builder | nested generator clause', (t) => {
         },
     })
 })
+
+test('suggestion Builder | no config', (t) => {
+    t.plan(1)
+
+    const result = suggestionBuilder().suggest('phrase', 'products')
+
+    t.deepEqual(result.getSuggestions(), {
+        suggest_phrase_products: {
+            phrase: {
+                field: 'products',
+            }
+        },
+    })
+})

--- a/test/suggestion-builder.js
+++ b/test/suggestion-builder.js
@@ -1,0 +1,35 @@
+import test from 'tape'
+import suggestionBuilder from '../src/suggestion-builder'
+
+
+test('suggestion Builder | term suggest', (t) => {
+    t.plan(1)
+  
+    const result = suggestionBuilder().suggest('term', 'products', { name: 'products', text: 'testing' })
+  
+    t.deepEqual(result.getSuggestion(), {
+      products: {
+        text: 'testing',
+        term: {
+          field: 'products',
+        }
+      }
+    })
+  })
+
+  test('suggestion Builder | term suggest with offset and length', (t) => {
+    t.plan(1)
+  
+    const result = suggestionBuilder().suggest('term', 'products', { name: 'products', text: 'testing', offset: 2, length: 10 })
+  
+    t.deepEqual(result.getSuggestion(), {
+      products: {
+        text: 'testing',
+        term: {
+          field: 'products',
+          offset: 2,
+          length: 10
+        }
+      }
+    })
+  })

--- a/test/suggestion-builder.js
+++ b/test/suggestion-builder.js
@@ -5,7 +5,7 @@ import suggestionBuilder from '../src/suggestion-builder'
 test('suggestion Builder | term suggest', (t) => {
     t.plan(1)
 
-    const result = suggestionBuilder().suggest('term', 'products', { text: 'testing' })
+    const result = suggestionBuilder().termSuggest('products', { text: 'testing' })
 
     t.deepEqual(result.getSuggestions(), {
         'suggest_term_products': {
@@ -20,12 +20,42 @@ test('suggestion Builder | term suggest', (t) => {
 test('suggestion Builder | term suggest with custom name', (t) => {
     t.plan(1)
 
-    const result = suggestionBuilder().suggest('term', 'products', { name: 'products', text: 'testing' })
+    const result = suggestionBuilder().termSuggest('products', { name: 'products', text: 'testing' })
 
     t.deepEqual(result.getSuggestions(), {
         products: {
             text: 'testing',
             term: {
+                field: 'products',
+            }
+        }
+    })
+})
+
+test('suggestion Builder | phrase suggest', (t) => {
+    t.plan(1)
+
+    const result = suggestionBuilder().phraseSuggest('products', { text: 'testing' })
+
+    t.deepEqual(result.getSuggestions(), {
+        'suggest_phrase_products': {
+            text: 'testing',
+            phrase: {
+                field: 'products',
+            }
+        }
+    })
+})
+
+test('suggestion Builder | phrase suggest with custom name', (t) => {
+    t.plan(1)
+
+    const result = suggestionBuilder().phraseSuggest('products', { name: 'products', text: 'testing' })
+
+    t.deepEqual(result.getSuggestions(), {
+        products: {
+            text: 'testing',
+            phrase: {
                 field: 'products',
             }
         }

--- a/test/suggestion-builder.js
+++ b/test/suggestion-builder.js
@@ -61,3 +61,44 @@ test('suggestion Builder | phrase suggest with custom name', (t) => {
         }
     })
 })
+
+test('suggestion Builder | chained suggests', (t) => {
+    t.plan(1)
+
+    const result = suggestionBuilder().suggest('phrase', 'products', { name: 'products', text: 'testing' }).suggest('term', 'brands', { name: 'brands', text: 'testing'})
+
+    t.deepEqual(result.getSuggestions(), {
+        products: {
+            text: 'testing',
+            phrase: {
+                field: 'products',
+            }
+        },
+        brands: {
+            text: 'testing',
+            term: {
+                field: 'brands',
+            }
+        }
+    })
+})
+
+
+test('suggestion Builder | nested generator clause', (t) => {
+    t.plan(1)
+
+    const result = suggestionBuilder().suggest('phrase', 'products', { name: 'products', text: 'testing', direct_generator: { field: 'name.trigram', suggest_mode: 'popular'} })
+
+    t.deepEqual(result.getSuggestions(), {
+        products: {
+            text: 'testing',
+            phrase: {
+                field: 'products',
+                direct_generator: {
+                    field: 'name.trigram',
+                    suggest_mode: 'popular',
+                }
+            }
+        },
+    })
+})

--- a/typing-tests/bodybuilder-tests.ts
+++ b/typing-tests/bodybuilder-tests.ts
@@ -341,11 +341,10 @@ bodybuilder()
     .build()
 
 bodybuilder()
-    .suggest('term', 'name', { text: 'this is text' })
-    .build()
-
-bodybuilder()
-    .suggest('term', 'name', { name: 'test', text: 'this is text' })
+    .termSuggest('field', { text: 'this is text' })
+    .termSuggest('field', { name: 'test', text: 'this is text', analyzer: 'english' })
+    .phraseSuggest('field', { text: 'this is text' })
+    .phraseSuggest('field', { name: 'test', text: 'this is text', size: 1, gram_size: 4, analyzer: 'english' })
     .build()
 
 bodybuilder()

--- a/typing-tests/bodybuilder-tests.ts
+++ b/typing-tests/bodybuilder-tests.ts
@@ -341,10 +341,8 @@ bodybuilder()
     .build()
 
 bodybuilder()
-    .termSuggest('field', { text: 'this is text' })
-    .termSuggest('field', { name: 'test', text: 'this is text', analyzer: 'english' })
-    .phraseSuggest('field', { text: 'this is text' })
-    .phraseSuggest('field', { name: 'test', text: 'this is text', size: 1, gram_size: 4, analyzer: 'english' })
+    .suggest('term', 'field', { text: 'this is text', analyzer: 'english' })
+    .suggest('phrase', 'field', { text: 'this is text', size: 1, gram_size: 2 })
     .build()
 
 bodybuilder()

--- a/typing-tests/bodybuilder-tests.ts
+++ b/typing-tests/bodybuilder-tests.ts
@@ -341,5 +341,13 @@ bodybuilder()
     .build()
 
 bodybuilder()
+    .suggest('term', 'name', { name: 'test', text: 'this is text' })
+    .build()
+
+bodybuilder()
+    .suggest('term', 'name', { name: 'test', text: 'this is text', options: [{}], offset: 1, length: 10 })
+    .build()
+
+bodybuilder()
     .clone()
     .size(1)

--- a/typing-tests/bodybuilder-tests.ts
+++ b/typing-tests/bodybuilder-tests.ts
@@ -341,11 +341,11 @@ bodybuilder()
     .build()
 
 bodybuilder()
-    .suggest('term', 'name', { name: 'test', text: 'this is text' })
+    .suggest('term', 'name', { text: 'this is text' })
     .build()
 
 bodybuilder()
-    .suggest('term', 'name', { name: 'test', text: 'this is text', options: [{}], offset: 1, length: 10 })
+    .suggest('term', 'name', { name: 'test', text: 'this is text' })
     .build()
 
 bodybuilder()


### PR DESCRIPTION
This is a really simple implementation of the suggest api, and handles a basic term suggest. There is still lots to implement, just wanted to open early for directional feedback. So far, I've basically copied the `aggregation_builder` with a few changes.

~Since the ES suggest api is a bit different from the query or aggs, I'm considering removing the `type` argument in lieu of specific methods for the suggest types. ex:~

```typescript
const bb = bodyBuilder();
bb.termSuggest('field', { ...options })
bb.phraseSuggest('field', {...options})
```

~which would let us having nicer typings between the methods. Considering the `phrase` suggest api is a far departure from the `term` suggest, I think having separate stronger typing would be a big bonus for dev experience. This way we can also add support for all suggesters (I think `term`, `phrase`, `completion` and `context`) incrementally while maintaining backwards compatibility.~

~edit: went ahead and pushed a better example of what I outlined above ^~

This PR resolves #263 